### PR TITLE
Whitelist and .map workshop support

### DIFF
--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -11,6 +11,15 @@ namespace MatchZy
     public partial class MatchZy
     {
 
+        [ConsoleCommand("matchzy_whitelist_enabled_default", "Whether Whitelist is enabled by default or not. Default value: false")]
+        public void MatchZyWLConvar(CCSPlayerController? player, CommandInfo command)
+        {
+            if (player != null) return;
+            string args = command.ArgString;
+
+            isWhitelistRequired = bool.TryParse(args, out bool isWhitelistRequiredValue) ? isWhitelistRequiredValue : args != "0" && isWhitelistRequired;
+        }
+        
         [ConsoleCommand("matchzy_knife_enabled_default", "Whether knife round is enabled by default or not. Default value: true")]
         public void MatchZyKnifeConvar(CCSPlayerController? player, CommandInfo command)
         {

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -16,6 +16,19 @@ namespace MatchZy
 {
     public partial class MatchZy
     {
+        [ConsoleCommand("css_wl", "Toggles Whitelist")]
+        public void OnWLCommand(CCSPlayerController? player, CommandInfo? command) {            
+            if (IsPlayerAdmin(player)) {
+                isWhitelistRequired = !isWhitelistRequired;
+                string WLStatus = isWhitelistRequired ? "Enabled" : "Disabled";
+                if (player == null) {
+                    ReplyToUserCommand(player, $"Whitelist is now {WLStatus}!");
+                } else {
+                    player.PrintToChat($"{chatPrefix} Whitelist is now {ChatColors.Green}{WLStatus}{ChatColors.Default}!");
+                }
+            }
+        }
+        
         [ConsoleCommand("css_ready", "Marks the player ready")]
         public void OnPlayerReady(CCSPlayerController? player, CommandInfo? command) {
             if (player == null) return;

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -129,7 +129,7 @@ namespace MatchZy
 		        if(player.IsBot) return;
 		        var steamId = player.SteamID;
 		
-		        string whitelistfileName = "puggr/whitelist.cfg";
+		        string whitelistfileName = "MatchZy/whitelist.cfg";
 		        string whitelistPath = Path.Join(Server.GameDirectory + "/csgo/cfg", whitelistfileName);
 		
 		        if(!File.Exists(whitelistPath)) File.WriteAllLines(whitelistPath, new []{"Steamid1", "Steamid2"});

--- a/Utility.cs
+++ b/Utility.cs
@@ -401,7 +401,9 @@ namespace MatchZy
             if (player == null) return;
             if (!IsPlayerAdmin(player)) return;
 
-            if (Server.IsMapValid(mapName)) {
+            if (long.TryParse(mapName, out _)) { // Check if mapName is a long for workshop map ids
+                Server.ExecuteCommand($"host_workshop_map \"{mapName}\"");
+            } else if (Server.IsMapValid(mapName)) {
                 Server.ExecuteCommand($"changelevel \"{mapName}\"");
             } else {
                 player.PrintToChat($"{chatPrefix} Invalid map name!");

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -2,6 +2,10 @@
 // Do not add commands other than matchzy config console variables
 // More configurations and variables will be coming in future updates.
 
+// Whether whitelist is enabled by default or not. Default value: false
+// This is the default value, but whitelist can be toggled by admin using .whitelist command
+matchzy_whitelist_enabled_default false
+
 // Whether knife round is enabled by default or not. Default value: true
 // This is the default value, but knife can be toggled by admin using .knife command
 matchzy_knife_enabled_default true


### PR DESCRIPTION
A Whitelist is very useful for content creators since the server pw can be easily leaked


I also added a check to the .map chat command that checks if the input is a long to interpret it as a workshop map code and use host_workshop_map instead, if its not a long it checks if the map is valid etc