### PR TITLE
Add side switching commands in practice mode

### DIFF
--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -130,7 +130,11 @@ namespace MatchZy
                 { ".uncoach", OnUnCoachCommand },
                 { ".exitprac", OnMatchCommand },
                 { ".stop", OnStopCommand },
-                { ".help", OnHelpCommand }
+                { ".help", OnHelpCommand },
+                { ".t", OnTCommand },
+                { ".ct", OnCTCommand },
+                { ".spec", OnSpecCommand },
+                { ".fas", OnFASCommand }
             };
 
             RegisterEventHandler<EventPlayerConnectFull>((@event, info) => {

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -776,6 +776,47 @@ namespace MatchZy
             RemoveGrenadeEntities();
         }
 
+        [ConsoleCommand("css_t", "Switches team to Terrorist")]
+        public void OnTCommand(CCSPlayerController? player, CommandInfo? command) {
+            if (!isPractice || player == null) return;
+
+            SideSwitchCommand(player, CsTeam.Terrorist);
+        }
+
+        [ConsoleCommand("css_ct", "Switches team to Counter-Terrorist")]
+        public void OnCTCommand(CCSPlayerController? player, CommandInfo? command) {
+            if (!isPractice || player == null) return;
+
+            SideSwitchCommand(player, CsTeam.CounterTerrorist);
+        }
+
+        [ConsoleCommand("css_spec", "Switches team to Spectator")]
+        public void OnSpecCommand(CCSPlayerController? player, CommandInfo? command) {
+            if (!isPractice || player == null) return;
+
+            SideSwitchCommand(player, CsTeam.Spectator);
+        }
+
+        [ConsoleCommand("css_fas", "Switches all other players to spectator")]
+        public void OnFASCommand(CCSPlayerController? player, CommandInfo? command) {
+            if (!isPractice || player == null) return;
+
+            SideSwitchCommand(player, CsTeam.None);
+        }
+
+        // CsTeam.None is a special value to mean force all other players to spectator
+        private void SideSwitchCommand(CCSPlayerController player, CsTeam team) {
+          if (team > CsTeam.None) {
+            player.ChangeTeam(team);
+            return;
+          }
+          Utilities.GetPlayers().ForEach((x) => { 
+              if(x.IsValid && !x.IsBot && x.UserId != player.UserId) {
+                x.ChangeTeam(CsTeam.Spectator);
+              }
+            });
+        }
+
         public void RemoveGrenadeEntities()
         {
             if (!isPractice) return;

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Most of the commands can also be used using ! prefix instead of . (like !ready)
 - `.deletenade <name>` Deletes a lineup from file
 - `.importnade <code>` Upon saving a lineup a code will be printed to chat, alternatively those can be retrieved from the savednades.cfg
 - `.listnades <optional filter>` Lists either all saved lineups ever or if given a filter only those that match the filter
+- `.ct, .t, .spec` Switches team to specified team
+- `.fas` Forces all other players to the spectator team
 
 ### Admin Commands
 

--- a/Utility.cs
+++ b/Utility.cs
@@ -845,6 +845,7 @@ namespace MatchZy
             {
                 ReplyToUserCommand(player, "Available commands: .spawn, .ctspawn, .tspawn, .bot, .nobots, .god, .clear, .fastforward");
                 ReplyToUserCommand(player, ".loadnade <name>, .savenade <name>, .importnade <code> .listnades <optional filter>");
+                ReplyToUserCommand(player, ".ct, .t, .spec, .fas");
                 return;
             }
             if (readyAvailable)


### PR DESCRIPTION
This PR adds `.ct, .t, .spec, .fas` commands

The first 3 work as you would expect, but `.fas` forces all other players to spectator

This can't be merged until roflmuffin/CounterStrikeSharp#139 is fixed.

There's a world where we'd want to roll in support for `css_switch` and `css_stay` so teams after winning knife can just pick a team declaratively rather than imperatively switching or not.