### PR TITLE
.bot improvements

### DIFF
--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -682,7 +682,6 @@ namespace MatchZy
                         continue;
                     }
                     pracUsedBots[tempPlayer.UserId.Value] = new Dictionary<string, object>();
-                    Log($"Adding bot {tempPlayer.PlayerName} to pracUsedBots");
 
                     Position botOwnerPosition = new Position(botOwner.PlayerPawn.Value.CBodyComponent?.SceneNode?.AbsOrigin, botOwner.PlayerPawn.Value.CBodyComponent?.SceneNode?.AbsRotation);
                     // Add key-value pairs to the inner dictionary
@@ -707,7 +706,6 @@ namespace MatchZy
 
 
             // Reference collision code: https://github.com/Source2ZE/CS2Fixes/blob/f009e399ff23a81915e5a2b2afda20da2ba93ada/src/events.cpp#L150
-            Log($"wobby state: {p1.PlayerPawn.Value.Collision.CollisionGroup}");
             p1.PlayerPawn.Value.Collision.CollisionAttribute.CollisionGroup = (byte)CollisionGroup.COLLISION_GROUP_DEBRIS;
             p1.PlayerPawn.Value.Collision.CollisionGroup = (byte)CollisionGroup.COLLISION_GROUP_DEBRIS;
             p2.PlayerPawn.Value.Collision.CollisionAttribute.CollisionGroup = (byte)CollisionGroup.COLLISION_GROUP_DEBRIS;
@@ -748,7 +746,6 @@ namespace MatchZy
             p1max = p1.Collision.Maxs + p1pos!;
             p2min = p2.Collision.Mins + p2pos!;
             p2max = p2.Collision.Maxs + p2pos!;
-            /* Log($"p1 ({p1min}, {p1max}), p2 ({p2min}, {p2max})"); */
 
             return p1min.X <= p2max.X && p1max.X >= p2min.X &&
                     p1min.Y <= p2max.Y && p1max.Y >= p2min.Y &&

--- a/cfg/MatchZy/prac.cfg
+++ b/cfg/MatchZy/prac.cfg
@@ -34,4 +34,7 @@ mp_warmup_start
 bot_quota_mode fill
 mp_solid_teammates 2
 mp_autoteambalance false
-mp_teammates_are_enemies true
+mp_teammates_are_enemies false
+buddha 1
+buddha_ignore_bots 1
+buddha_reset_hp 100


### PR DESCRIPTION
This pr is pretty sizable, a lot of stuff was referenced from splewis' csgo practice mode plugin.

The biggest changes are bots now don't move when you bump into them, because they spawn on the enemy team. To remedy the fact noclip was required to get the player out, we set the collisions on both player and bot to be noblock until they're no longer colliding.

I also added a much needed `buddha` to prac.cfg, which should be automatically unpracc'd via the `sv_cheats 0`.