### PR TITLE
added a command to enable nades to be saved globally instead of being privated for each player

### DIFF
--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -37,6 +37,15 @@ namespace MatchZy
             isPlayOutEnabled = bool.TryParse(args, out bool isPlayOutEnabledValue) ? isPlayOutEnabledValue : args != "0" && isPlayOutEnabled;
         }
 
+        [ConsoleCommand("matchzy_save_nades_as_global_enabled", "Whether nades should be saved globally instead of being privated to players by default or not. Default value: false")]
+        public void MatchZySaveNadesAsGlobalConvar(CCSPlayerController? player, CommandInfo command)
+        {
+            if (player != null) return;
+            string args = command.ArgString;
+
+            isPlayOutEnabled = bool.TryParse(args, out bool isPlayOutEnabledValue) ? isPlayOutEnabledValue : args != "0" && isPlayOutEnabled;
+        }
+
         [ConsoleCommand("matchzy_minimum_ready_required", "Minimum ready players required to start the match. Default: 1")]
         public void MatchZyMinimumReadyRequired(CCSPlayerController? player, CommandInfo command)
         {

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -30,6 +30,21 @@ namespace MatchZy
                 SendPlayerNotAdminMessage(player);
             }
         }
+
+        [ConsoleCommand("css_save_nades_as_global", "Toggles Global Lineups for players")]
+        public void OnSaveNadesAsGlobalCommand(CCSPlayerController? player, CommandInfo? command) {            
+            if (IsPlayerAdmin(player, "css_save_nades_as_global", "@css/config")) {
+                isSaveNadesAsGlobalEnabled = !isSaveNadesAsGlobalEnabled;
+                string GlobalNadesStatus = isSaveNadesAsGlobalEnabled ? "Enabled" : "Disabled";
+                if (player == null) {
+                    ReplyToUserCommand(player, $"Saving/Loading Lineups Globally is now {GlobalNadesStatus}!");
+                } else {
+                    player.PrintToChat($"{chatPrefix} Saving/Loading Lineups Globally is now {ChatColors.Green}{GlobalNadesStatus}{ChatColors.Default}!");
+                }
+            } else {
+                SendPlayerNotAdminMessage(player);
+            }
+        }
         
         [ConsoleCommand("css_ready", "Marks the player ready")]
         public void OnPlayerReady(CCSPlayerController? player, CommandInfo? command) {

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -64,6 +64,7 @@ namespace MatchZy
         public bool isKnifeRequired = true;
         public int minimumReadyRequired = 2; // Number of ready players required start the match. If set to 0, all connected players have to ready-up to start the match.
         public bool isWhitelistRequired = false;
+        public bool isSaveNadesAsGlobalEnabled = false;
 
         public bool isPlayOutEnabled = false;
 
@@ -118,6 +119,7 @@ namespace MatchZy
                 { ".reloadmap", OnMapReloadCommand },
                 { ".settings", OnMatchSettingsCommand },
                 { ".whitelist", OnWLCommand },
+                { ".globalnades", OnSaveNadesAsGlobalCommand },
                 { ".reload_admins", OnReloadAdmins },
                 { ".prac", OnPracCommand },
                 { ".bot", OnBotCommand },

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -166,7 +166,16 @@ namespace MatchZy
                 string lineupDesc = string.Join(" ", lineupUserString, 1, lineupUserString.Length - 1);
 
                 // Get player info: steamid, pos, ang
-                string playerSteamID = player.SteamID.ToString();
+                string playerSteamID;
+                if(isSaveNadesAsGlobalEnabled == false)
+                {
+                    playerSteamID = player.SteamID.ToString();
+                }
+                else
+                {
+                    playerSteamID = "default";
+                }
+
                 QAngle playerAngle = player.PlayerPawn.Value.EyeAngles;
                 Vector playerPos = player.Pawn.Value.CBodyComponent!.SceneNode.AbsOrigin;
                 string currentMapName = Server.MapName;
@@ -223,7 +232,7 @@ namespace MatchZy
                     //Reply to user
                     ReplyToUserCommand(player, $" \x0DLineup \x06'{lineupName}' \x0Dsaved successfully!");
 					player.PrintToCenter($"Lineup '{lineupName}' saved successfully!");
-					ReplyToUserCommand(player, $" \x0DLineup Code: \x06{lineupName} {playerPos} {playerAngle}");
+					Server.PrintToChatAll($"{chatPrefix} \x0D{player.PlayerName} Just saved a Lineup! Lineup Code: \x06{lineupName} {playerPos} {playerAngle}");
                 }
                 catch (JsonException ex)
                 {
@@ -243,7 +252,15 @@ namespace MatchZy
             if (!string.IsNullOrWhiteSpace(saveNadeName))
             {
                 // Grab player steamid
-                string playerSteamID = player.SteamID.ToString();
+                string playerSteamID;
+                if(isSaveNadesAsGlobalEnabled == false)
+                {
+                    playerSteamID = player.SteamID.ToString();
+                }
+                else
+                {
+                    playerSteamID = "default";
+                }
 
                 // Define the file path
                 string savednadesfileName = "MatchZy/savednades.json";

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -44,3 +44,6 @@ matchzy_chat_messages_timer_delay 12
 // Whether playout (play max rounds) is enabled. Default value: false
 // This is the default value, but playout can be toggled by admin using .playout command
 matchzy_playout_enabled_default false
+
+// Whether nades should be saved globally instead of being privated to players by default or not. Default value: false
+matchzy_save_nades_as_global_enabled false


### PR DESCRIPTION
chat command: `.globalnades` perms: `@css/config`
config convar: `matchzy_save_nades_as_global_enabled`

![3](https://github.com/shobhit-pathak/MatchZy/assets/43534349/f5631af5-5ffe-4616-8912-c3c898344f65)


