### PR TITLE
Adding AutoStart ConVar and Sleep mode

### DIFF
--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -145,5 +145,18 @@ namespace MatchZy
             }
         }
 
+        [ConsoleCommand("matchzy_autostart_mode", "Whether the plugin will load the match mode, the practice moder or neither by startup. Default: 1")]
+        public void MatchZyAutoStartConvar(CCSPlayerController? player, CommandInfo command)
+        {
+            if (player != null) return;
+            string args = command.ArgString;
+
+            if (int.TryParse(args, out int autoStartModeValue))
+            {
+                autoStartMode = autoStartModeValue;
+            }
+
+        }
+
     }
 }

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -21,15 +21,17 @@ namespace MatchZy
         public string chatPrefix = $"[{ChatColors.Green}MatchZy{ChatColors.Default}]";
         public string adminChatPrefix = $"[{ChatColors.Red}ADMIN{ChatColors.Default}]";
 
-        // Match phase data
+        // Plugin start phase data
         public bool isPractice = false;
-        public bool readyAvailable = true;
+	public bool isSleep = false;
+        public bool readyAvailable = false;
         public bool matchStarted = false;
-        public bool isWarmup = true;
+        public bool isWarmup = false;
         public bool isKnifeRound = false;
         public bool isSideSelectionPhase = false;
         public bool isMatchLive = false;
         public long liveMatchId = -1;
+	public int autoStartMode = 0;
 
         // Pause Data
         public bool isPaused = false;
@@ -89,7 +91,7 @@ namespace MatchZy
             reverseTeamSides["TERRORIST"] = matchzyTeam2;
 
             if (!hotReload) {
-                StartWarmup();
+                AutoStart();
             } else {
                 // Pluign should not be reloaded while a match is live (this would messup with the match flags which were set)
                 // Only hot-reload the plugin if you are testing something and don't want to restart the server time and again.
@@ -185,7 +187,7 @@ namespace MatchZy
                     if (GetRealPlayersCount() == 1) {
                         Log($"[FULL CONNECT] First player has connected, starting warmup!");
                         ExecUnpracCommands();
-                        StartWarmup();
+                        AutoStart();
                     }
                 }
                 return HookResult.Continue;

--- a/SleepMode.cs
+++ b/SleepMode.cs
@@ -1,0 +1,70 @@
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Modules.Commands;
+using CounterStrikeSharp.API.Modules.Utils;
+using CounterStrikeSharp.API.Modules.Timers;
+using CounterStrikeSharp.API.Modules.Memory;
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Net.Mime;
+
+
+
+namespace MatchZy
+{
+
+    public partial class MatchZy
+    {
+        public const string sleepCfgPath = "MatchZy/sleep.cfg";
+
+        public void StartSleepMode()
+        {
+            if (matchStarted) return;
+            isSleep = true;
+            isPractice = false;
+            isWarmup = false;
+            readyAvailable = false;
+            matchStarted = false;
+            isSideSelectionPhase = false;
+            isMatchLive = false;
+
+            var absolutePath = Path.Join(Server.GameDirectory + "/csgo/cfg", sleepCfgPath);
+
+            if (File.Exists(Path.Join(Server.GameDirectory + "/csgo/cfg", sleepCfgPath)))
+            {
+                Log($"Starting Sleep Mode! Executing Sleep CFG from {sleepCfgPath}");
+                Server.ExecuteCommand($"exec {sleepCfgPath}");
+            }
+            else
+            {
+                Log($"Starting Sleep Mode! Sleep CFG not found in {absolutePath}, using default CFG!");
+                ExecUnpracCommands();
+                Server.ExecuteCommand("""exec gamemode_competitive.cfg;""");
+            }
+            Server.PrintToChatAll($"{chatPrefix} [MatchZy] deactivated!");
+        }
+
+        [ConsoleCommand("css_sleep", "Starts sleep mode")]
+        public void OnSleepCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (!IsPlayerAdmin(player, "css_sleep", "@css/map", "@custom/prac"))
+            {
+                SendPlayerNotAdminMessage(player);
+                return;
+            }
+
+            if (matchStarted)
+            {
+                ReplyToUserCommand(player, "Sleep Mode cannot be started when a match has been started!");
+                return;
+            }
+            StartSleepMode();
+        }
+
+    }
+}

--- a/Utility.cs
+++ b/Utility.cs
@@ -868,5 +868,21 @@ namespace MatchZy
         private void Log(string message) {
             Console.WriteLine("[MatchZy] " + message);
         }
+
+        private void AutoStart()
+        {
+            if (autoStartMode == 0)
+            {
+                StartSleepMode();
+            }
+            if (autoStartMode == 1)
+            {
+                StartWarmup();
+            }
+            if (autoStartMode == 2)
+            {
+                StartPracticeMode();
+            }
+        }
     }
 }

--- a/Utility.cs
+++ b/Utility.cs
@@ -810,7 +810,7 @@ namespace MatchZy
 
         private void StartMatchMode() 
         {
-            if (matchStarted || !isPractice) return;
+            if (matchStarted || (!isPractice && !isSleep)) return;
             ExecUnpracCommands();
             ResetMatch();
             Server.PrintToChatAll($"{chatPrefix} Match mode loaded!");

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -44,3 +44,7 @@ matchzy_chat_messages_timer_delay 12
 // Whether playout (play max rounds) is enabled. Default value: false
 // This is the default value, but playout can be toggled by admin using .playout command
 matchzy_playout_enabled_default false
+
+// Whether the plugin will load the match mode, the practice moder or neither by startup
+// This is the default value, 0 for neither, 1 for match mode, 2 for practice mode
+matchzy_autostart_mode 1


### PR DESCRIPTION
My own implementation of my enhancement request to be able to "deactivate" the plugin.

To do so I add a "SleepMode", following the logic of the PracticeMode. In the SleepMode the plugin is simply doing nothing.

I add a sleep.cfg where the user can choose which settings should be loading while going in sleep mode and I add a css_sleep command to start the sleep mode whenever the user want to.

To use this SleepMode at startup I also add a AutoStart ConVar, where the user can choose what function of the plugin should load with server start. Default is the match mode, so the nothing changes in the default settings. But the SleepMod and the PracticeMode can also be chosen.

Note: My experience in C# is limited. I basically just copied the existing code and made some changes. I am sure the PR is not coded pretty. 
I tested these changes on my server and we decided to use this version, so I want to share this.
