### PR TITLE
Fix obsolete entityindex

### DIFF
--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -7,7 +7,7 @@ using CounterStrikeSharp.API.Core.Attributes;
 
 namespace MatchZy
 {
-    [MinimumApiVersion(68)]
+    [MinimumApiVersion(84)]
     public partial class MatchZy : BasePlugin
     {
 

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -493,22 +493,22 @@ namespace MatchZy
                                 switch (lineupInfo["Type"])
                                 {
                                     case "Flash":
-                                        NativeAPI.IssueClientCommand(player.Slot, "slot7");
+                                        player.ExecuteClientCommand("slot7");
                                         break;
                                     case "Smoke":
-                                        NativeAPI.IssueClientCommand(player.Slot, "slot8");
+                                        player.ExecuteClientCommand("slot8");
                                         break;
                                     case "HE":
-                                        NativeAPI.IssueClientCommand(player.Slot, "slot6");
+                                        player.ExecuteClientCommand("slot6");
                                         break;
                                     case "Decoy":
-                                        NativeAPI.IssueClientCommand(player.Slot, "slot9");
+                                        player.ExecuteClientCommand("slot9");
                                         break;
                                     case "Molly":
-                                        NativeAPI.IssueClientCommand(player.Slot, "slot10");
+                                        player.ExecuteClientCommand("slot10");
                                         break;
                                     case "":
-                                        NativeAPI.IssueClientCommand(player.Slot, "slot8");
+                                        player.ExecuteClientCommand("slot8");
                                         break;
                                 }
 

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -493,22 +493,22 @@ namespace MatchZy
                                 switch (lineupInfo["Type"])
                                 {
                                     case "Flash":
-                                        NativeAPI.IssueClientCommand((int)player.EntityIndex!.Value.Value - 1, "slot7");
+                                        NativeAPI.IssueClientCommand(player.Slot, "slot7");
                                         break;
                                     case "Smoke":
-                                        NativeAPI.IssueClientCommand((int)player.EntityIndex!.Value.Value - 1, "slot8");
+                                        NativeAPI.IssueClientCommand(player.Slot, "slot8");
                                         break;
                                     case "HE":
-                                        NativeAPI.IssueClientCommand((int)player.EntityIndex!.Value.Value - 1, "slot6");
+                                        NativeAPI.IssueClientCommand(player.Slot, "slot6");
                                         break;
                                     case "Decoy":
-                                        NativeAPI.IssueClientCommand((int)player.EntityIndex!.Value.Value - 1, "slot9");
+                                        NativeAPI.IssueClientCommand(player.Slot, "slot9");
                                         break;
                                     case "Molly":
-                                        NativeAPI.IssueClientCommand((int)player.EntityIndex!.Value.Value - 1, "slot10");
+                                        NativeAPI.IssueClientCommand(player.Slot, "slot10");
                                         break;
                                     case "":
-                                        NativeAPI.IssueClientCommand((int)player.EntityIndex!.Value.Value - 1, "slot8");
+                                        NativeAPI.IssueClientCommand(player.Slot, "slot8");
                                         break;
                                 }
 


### PR DESCRIPTION
won't compile when using api from v81 onwards