### PR TITLE
Add correct get5 `gamestate` to `get5_status`

### DIFF
--- a/G5API.cs
+++ b/G5API.cs
@@ -12,13 +12,13 @@ namespace MatchZy
         public required string PluginVersion { get; set; }
 
         [JsonPropertyName("gamestate")]
-        public int GameState { get; set; }
+        public string GameState { get; set; }
     }
 
     public class G5WebAvailable
     {
         [JsonPropertyName("gamestate")]
-        public int GameState { get; init; }
+        public string GameState { get; init; }
 
         [JsonPropertyName("available")]
         public int Available { get; } = 1;
@@ -31,7 +31,57 @@ namespace MatchZy
         [ConsoleCommand("get5_status", "Returns get5 status")]
         public void Get5StatusCommand(CCSPlayerController? player, CommandInfo command)
         {
-            command.ReplyToCommand(JsonSerializer.Serialize(new Get5Status { PluginVersion = "0.15.0", GameState = 0 }));
+            // Get state from MatchZy state phase data and map to get5 state
+            // Get5 states: pre_veto, veto, warmup, knife, waiting_for_knife_decision, going_live, live, pending_restore, post_game
+            // Please note, that Get5 have moved from integer based states to string based states, so the integer based states are not used.
+            //
+            // TODO: Missing "going_live" state, as this is not tracked. It has an event (GoingLiveEvent), but it is not read (only ever dispatched).
+            //       Therefore, the `matchStarted && !isMatchLive` is used to determine if the match is going live (and no other state is "active")
+
+            string state = "none";
+
+            if (!isMatchSetup)
+            {
+                state = "none"; // If the match has not been set up, then the state is none
+            }
+            else if (isPreVeto)
+            {
+                state = "pre_veto";
+            }
+            else if (isVeto)
+            {
+                state = "veto";
+            }
+            else if (isWarmup)
+            {
+                state = "warmup";
+            }
+            else if (isKnifeRound)
+            {
+                state = "knife";
+            }
+            else if (isSideSelectionPhase)
+            {
+                state = "waiting_for_knife_decision";
+            }
+            else if (matchStarted && !isMatchLive)
+            {
+                state = "going_live";
+            }
+            else if (isMatchLive)
+            {
+                state = "live";
+            }
+            else if (isRoundRestoring)
+            {
+                state = "pending_restore";
+            }
+            else if (IsPostGamePhase())
+            {
+                state = "post_game";
+            }
+
+            command.ReplyToCommand(JsonSerializer.Serialize(new Get5Status { PluginVersion = "0.15.0", GameState = state }));
         }
 
         [ConsoleCommand("get5_web_available", "Returns get5 web available")]

--- a/G5API.cs
+++ b/G5API.cs
@@ -31,30 +31,38 @@ namespace MatchZy
         [ConsoleCommand("get5_status", "Returns get5 status")]
         public void Get5StatusCommand(CCSPlayerController? player, CommandInfo command)
         {
+            // TODO: Add remaining Get5 status data as specified in https://splewis.github.io/get5/latest/commands/#get5_status
+            command.ReplyToCommand(JsonSerializer.Serialize(new Get5Status { PluginVersion = "0.15.0", GameState = getGet5Gamestate() }));
+        }
+
+        [ConsoleCommand("get5_web_available", "Returns get5 web available")]
+        public void Get5WebAvailable(CCSPlayerController? player, CommandInfo command)
+        {
+            command.ReplyToCommand(JsonSerializer.Serialize(new G5WebAvailable()));
+        }
+
+        private string getGet5Gamestate()
+        {
             // Get state from MatchZy state phase data and map to get5 state
             // Get5 states: pre_veto, veto, warmup, knife, waiting_for_knife_decision, going_live, live, pending_restore, post_game
             // Please note, that Get5 have moved from integer based states to string based states, so the integer based states are not used.
             //
             // TODO: Missing "going_live" state, as this is not tracked. It has an event (GoingLiveEvent), but it is not read (only ever dispatched).
-            //       Therefore, the `matchStarted && !isMatchLive` is used to determine if the match is going live (and no other state is "active")
-
+            //       Therefore, a "proxy" is used to determine if the match is going live (and no other state is "active")
             string state = "none";
 
+            // The order of checks have been checked to work. Please be carefull if you change the order.
             if (!isMatchSetup)
             {
                 state = "none"; // If the match has not been set up, then the state is none
-            }
-            else if (isPreVeto)
-            {
-                state = "pre_veto";
             }
             else if (isVeto)
             {
                 state = "veto";
             }
-            else if (isWarmup)
+            else if (isPreVeto)
             {
-                state = "warmup";
+                state = "pre_veto";
             }
             else if (isKnifeRound)
             {
@@ -64,9 +72,9 @@ namespace MatchZy
             {
                 state = "waiting_for_knife_decision";
             }
-            else if (matchStarted && !isMatchLive)
+            else if (IsPostGamePhase())
             {
-                state = "going_live";
+                state = "post_game";
             }
             else if (isMatchLive)
             {
@@ -76,18 +84,16 @@ namespace MatchZy
             {
                 state = "pending_restore";
             }
-            else if (IsPostGamePhase())
+            else if (matchStarted)
             {
-                state = "post_game";
+                state = "going_live";
+            }
+            else if (isWarmup)
+            {
+                state = "warmup";
             }
 
-            command.ReplyToCommand(JsonSerializer.Serialize(new Get5Status { PluginVersion = "0.15.0", GameState = state }));
-        }
-
-        [ConsoleCommand("get5_web_available", "Returns get5 web available")]
-        public void Get5WebAvailable(CCSPlayerController? player, CommandInfo command)
-        {
-            command.ReplyToCommand(JsonSerializer.Serialize(new G5WebAvailable()));
+            return state;
         }
     }
 }


### PR DESCRIPTION
This updates the `gamestate`, returned in the `get5_status` command.

It is implemented in a *very* rough format, piecing together the information from booleans and methods that I could guess me to, had the correct information.  
With that said, it is tested through multiple CS2 matches (loaded from URL, and not practices, scrum, etc.), to work correctly.

The Get5 command `get5_status` still misses some elements, to be "in spec", to what Get5 respond with.  
The spec for Get5 can be seen at: https://splewis.github.io/get5/latest/commands/#get5_status

I can look into making another PR for some of the other information, to try to bring this into spec, with Get5.

The gamestate is changed from an int to a string, due to Get5 using this for their latest stable version.

**Why I have made this update:**  
Even though there exist Get5 web panels, I have made my own.  
This web panel is built upon the use of RCON directly to the server. Using already exposed systems, and making the panel a drop-in replacement, without having to look into the API plugin.  
That said, I will at some point look into the Get5API. Until then, I would like to use RCON to interact with the system.
With this update, I will be able to run matches through the system.

*As this is my first PR to this repo, and work with C#, there may be bugs, improvements or other areas, which does not live up to expected standards.*
*Please let me know, if any changes have to be made, to incorporate this.*