### PR TITLE
Feature: Match Scrim Mode

### DIFF
--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -249,5 +249,14 @@ namespace MatchZy
                 command.ReplyToCommand("Usage: matchzy_max_saved_last_grenades <number>");
             }
         }
+
+        [ConsoleCommand("matchzy_enable_match_scrim", "Allows match setup with no players defined and run like a scrim. Default value: False")]
+        public void MatchZyEnableMatchScrimConvar(CCSPlayerController? player, CommandInfo command)
+        {
+            if (player != null) return;
+            string args = command.ArgString;
+
+            enableMatchScrim = bool.TryParse(args, out bool enableMatchScrimValue) ? enableMatchScrimValue : args != "0" && enableMatchScrim;
+        }
     }
 }

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -61,8 +61,8 @@ namespace MatchZy
                     } else {
                         playerReadyStatus[player.UserId.Value] = true;
 
-                        if (enableMatchScrim && (player.TeamNum == 3 || player.TeamNum == 2)) {
-                            string teamName = player.TeamNum == 3 ? reverseTeamSides["CT"].teamName : reverseTeamSides["TERRORIST"].teamName;
+                        if (enableMatchScrim && (player.TeamNum == (int)CsTeam.CounterTerrorist || player.TeamNum == (int)CsTeam.Terrorist)) {
+                            string teamName = player.TeamNum == (int)CsTeam.CounterTerrorist ? reverseTeamSides["CT"].teamName : reverseTeamSides["TERRORIST"].teamName;
                             Server.PrintToChatAll($"{chatPrefix} You have been marked ready on team {ChatColors.Green}{teamName}{ChatColors.Default}!");
                         }
                         else {

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -60,7 +60,14 @@ namespace MatchZy
                         player.PrintToChat($"{chatPrefix} You are already ready!");
                     } else {
                         playerReadyStatus[player.UserId.Value] = true;
-                        player.PrintToChat($"{chatPrefix} You have been marked ready!");
+
+                        if (enableMatchScrim && (player.TeamNum == 3 || player.TeamNum == 2)) {
+                            string teamName = player.TeamNum == 3 ? reverseTeamSides["CT"].teamName : reverseTeamSides["TERRORIST"].teamName;
+                            Server.PrintToChatAll($"{chatPrefix} You have been marked ready on team {ChatColors.Green}{teamName}{ChatColors.Default}!");
+                        }
+                        else {
+                            player.PrintToChat($"{chatPrefix} You have been marked ready!");
+                        }
                     }
                     CheckLiveRequired();
                     HandleClanTags();

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -46,10 +46,13 @@ public partial class MatchZy
                 {
                     CsTeam team = GetPlayerTeam(player);
                     Log($"[EventPlayerConnectFull] KICKING PLAYER STEAMID: {steamId}, Name: {player.PlayerName} (NOT ALLOWED!)");
-                    if ((enableMatchScrim && matchStarted) || (!enableMatchScrim && team == CsTeam.None))
+                    if (enableMatchScrim && matchStarted || !enableMatchScrim)
                     {
-                        KickPlayer(player);
-                        return HookResult.Continue;
+                        if (team == CsTeam.None)
+                        {
+                            KickPlayer(player);
+                            return HookResult.Continue;
+                        }
                     }
                 }
             }

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -46,7 +46,7 @@ public partial class MatchZy
                 {
                     CsTeam team = GetPlayerTeam(player);
                     Log($"[EventPlayerConnectFull] KICKING PLAYER STEAMID: {steamId}, Name: {player.PlayerName} (NOT ALLOWED!)");
-                    if (!enableMatchScrim && team == CsTeam.None)
+                    if ((enableMatchScrim && matchStarted) || (!enableMatchScrim && team == CsTeam.None))
                     {
                         KickPlayer(player);
                         return HookResult.Continue;

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -46,7 +46,7 @@ public partial class MatchZy
                 {
                     CsTeam team = GetPlayerTeam(player);
                     Log($"[EventPlayerConnectFull] KICKING PLAYER STEAMID: {steamId}, Name: {player.PlayerName} (NOT ALLOWED!)");
-                    if (team == CsTeam.None)
+                    if (!enableMatchScrim && team == CsTeam.None)
                     {
                         KickPlayer(player);
                         return HookResult.Continue;

--- a/MapVeto.cs
+++ b/MapVeto.cs
@@ -340,6 +340,7 @@ namespace MatchZy
             // In case the sides don't match after selection, we check it here before writing the backup.
             // Also required if the map doesn't need to change.
             SetMapSides();
+            if (enableMatchScrim) LockTeamsManually();
             ExecuteChangedConvars();
             foreach (var key in playerReadyStatus.Keys) {
                 playerReadyStatus[key] = false;

--- a/MatchManagement.cs
+++ b/MatchManagement.cs
@@ -134,7 +134,7 @@ namespace MatchZy
             }
         }
 
-        static string ValidateMatchJsonStructure(JObject jsonData)
+        private string ValidateMatchJsonStructure(JObject jsonData)
         {
             string[] requiredFields = { "maplist", "team1", "team2", "num_maps" };
 
@@ -185,7 +185,7 @@ namespace MatchZy
                         {
                             return $"{field} should be a JSON structure!";
                         }
-                        if ((field != "spectators") && (jsonData[field]!["players"] == null || jsonData[field]!["players"]!.Type != JTokenType.Object)) 
+                        if ((field != "spectators") && (!enableMatchScrim) && (jsonData[field]!["players"] == null || jsonData[field]!["players"]!.Type != JTokenType.Object)) 
                         {
                             return $"{field} should have 'players' JSON!";
                         }

--- a/MatchManagement.cs
+++ b/MatchManagement.cs
@@ -378,24 +378,31 @@ namespace MatchZy
         }
 
         public bool LockTeamsManually() {
-            CsTeam team1 = teamSides[matchzyTeam1] == "CT" ? CsTeam.CounterTerrorist : CsTeam.Terrorist;
-            CsTeam team2 = teamSides[matchzyTeam2] == "CT" ? CsTeam.CounterTerrorist : CsTeam.Terrorist;
+            try {
+                CsTeam team1 = teamSides[matchzyTeam1] == "CT" ? CsTeam.CounterTerrorist : CsTeam.Terrorist;
+                CsTeam team2 = teamSides[matchzyTeam2] == "CT" ? CsTeam.CounterTerrorist : CsTeam.Terrorist;
 
-            Dictionary<ulong, string> team1Players = new();
-            Dictionary<ulong, string> team2Players = new();
-            Dictionary<ulong, string> spectatorPlayers = new();
+                Dictionary<ulong, string> team1Players = new();
+                Dictionary<ulong, string> team2Players = new();
+                Dictionary<ulong, string> spectatorPlayers = new();
 
-            foreach (var key in playerData.Keys)
-            {
-                if (!playerData[key].IsValid) continue;
-                if (playerData[key].TeamNum == (int)team1) team1Players.Add(playerData[key].SteamID, playerData[key].PlayerName);
-                else if (playerData[key].TeamNum == (int)team2) team2Players.Add(playerData[key].SteamID, playerData[key].PlayerName);
-                else if (playerData[key].TeamNum == (int)CsTeam.Spectator) spectatorPlayers.Add(playerData[key].SteamID, playerData[key].PlayerName);
+                foreach (var key in playerData.Keys)
+                {
+                    if (!playerData[key].IsValid) continue;
+                    if (playerData[key].TeamNum == (int)team1) team1Players.Add(playerData[key].SteamID, playerData[key].PlayerName);
+                    else if (playerData[key].TeamNum == (int)team2) team2Players.Add(playerData[key].SteamID, playerData[key].PlayerName);
+                    else if (playerData[key].TeamNum == (int)CsTeam.Spectator) spectatorPlayers.Add(playerData[key].SteamID, playerData[key].PlayerName);
+                }
+
+                matchzyTeam1.teamPlayers = JToken.FromObject(team1Players);
+                matchzyTeam2.teamPlayers = JToken.FromObject(team2Players);
+                matchConfig.Spectators = JToken.FromObject(spectatorPlayers);
             }
-
-            matchzyTeam1.teamPlayers = JToken.FromObject(team1Players);
-            matchzyTeam2.teamPlayers = JToken.FromObject(team2Players);
-            matchConfig.Spectators = JToken.FromObject(spectatorPlayers);
+            catch (Exception e)
+            {
+                Log($"[LockTeamsManually - FATAL] An error occured: {e.Message}");
+                return false;
+            }
 
             return true;
         }

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -228,8 +228,11 @@ namespace MatchZy
                 if (isMatchSetup && player != null && player.IsValid) {
                     if (int.TryParse(info.ArgByIndex(1), out int joiningTeam)) {
                         int playerTeam = (int)GetPlayerTeam(player);
-                        if (!enableMatchScrim && joiningTeam != playerTeam) {
-                            return HookResult.Stop;
+                        // if scrim, then only check once match has started
+                        if ((enableMatchScrim && matchStarted) || !enableMatchScrim) {
+                            if (joiningTeam != playerTeam) {
+                                return HookResult.Stop;
+                            }
                         }
                     }
                 }

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -228,7 +228,7 @@ namespace MatchZy
                 if (isMatchSetup && player != null && player.IsValid) {
                     if (int.TryParse(info.ArgByIndex(1), out int joiningTeam)) {
                         int playerTeam = (int)GetPlayerTeam(player);
-                        if (joiningTeam != playerTeam) {
+                        if (!enableMatchScrim && joiningTeam != playerTeam) {
                             return HookResult.Stop;
                         }
                     }

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -50,6 +50,8 @@ namespace MatchZy
 
         public List<int> noFlashList = new List<int>();
 
+        public bool enableMatchScrim = false;
+
         public void StartPracticeMode()
         {
             if (matchStarted) return;

--- a/Utility.cs
+++ b/Utility.cs
@@ -414,7 +414,7 @@ namespace MatchZy
 
                     if (isMatchSetup || matchModeOnly) {
                         CsTeam team = GetPlayerTeam(player);
-                        if (team == CsTeam.None && player.UserId.HasValue) {
+                        if (!enableMatchScrim && team == CsTeam.None && player.UserId.HasValue) {
                             Server.ExecuteCommand($"kickid {(ushort)player.UserId}");
                             continue;
                         }

--- a/Utility.cs
+++ b/Utility.cs
@@ -414,7 +414,7 @@ namespace MatchZy
 
                     if (isMatchSetup || matchModeOnly) {
                         CsTeam team = GetPlayerTeam(player);
-                        if (!enableMatchScrim && team == CsTeam.None && player.UserId.HasValue) {
+                        if (((enableMatchScrim && matchStarted) || !enableMatchScrim) && team == CsTeam.None && player.UserId.HasValue) {
                             Server.ExecuteCommand($"kickid {(ushort)player.UserId}");
                             continue;
                         }

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -78,3 +78,6 @@ matchzy_allow_force_ready true
 
 // Maximum number of grenade history that may be saved per-map, per-client. Set to 0 to disable the limit and allow unlimited grenades to be stored. Default value: 512
 matchzy_max_saved_last_grenades 512
+
+// Allows match setup with no players defined and run like a scrim. Default value: False
+matchzy_enable_match_scrim false

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -111,6 +111,9 @@ Example: `matchzy_demo_upload_url "https://your-website.com/upload-endpoint"` <b
 ####`matchzy_max_saved_last_grenades`
 :   Maximum number of grenade history that may be saved per-map, per-client. Set to 0 to disable the limit and allow unlimited grenades to be stored.<br>**`Default: 512`**
 
+####`matchzy_enable_match_scrim`
+:   Allows match setup with no players defined and run like a scrim.<br>**`Default: false`**
+
 ### Configuring Warmup/Knife/Live/Prac CFGs
 Again, inside `csgo/cfg/MatchZy`, files named `warmup.cfg`, `knife.cfg`, `live.cfg` and `prac.cfg` should be present. These configs are executed when Warmup, Knife, Live and Practice Mode is started respectively.
 


### PR DESCRIPTION
This is to allow scrims (no configured players) using match setup. I have added a convar to track whether to enable this scrim mode [matchzy_enable_match_scrim], which will default to False.

Players will be able to switch teams before the match goes live (eg: warmup, veto, knife round). This isn't perfect, but at this stage, I don't believe there's a better point to lock the teams.