### PR TITLE
Feature: Skip Veto

### DIFF
--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -231,9 +231,9 @@ namespace MatchZy
             if (IsPlayerAdmin(player, "css_skipveto", "@css/config")) {
                 if (matchStarted) {
                     if (player == null) {
-                        ReplyToUserCommand(player, $"Skip veto command cannot be used if match Match has already started!");
+                        ReplyToUserCommand(player, $"Skip veto command cannot be used if match has already started!");
                     } else {
-                        player.PrintToChat($"{chatPrefix} Skip veto command cannot be used if match Match has already started!");
+                        player.PrintToChat($"{chatPrefix} Skip veto command cannot be used if match has already started!");
                     }
                 }
                 else {

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -231,9 +231,9 @@ namespace MatchZy
             if (IsPlayerAdmin(player, "css_skipveto", "@css/config")) {
                 if (matchStarted) {
                     if (player == null) {
-                        ReplyToUserCommand(player, $"Match has already started!");
+                        ReplyToUserCommand(player, $"Skip veto command cannot be used if match Match has already started!");
                     } else {
-                        player.PrintToChat($"{chatPrefix} Match has already started!");
+                        player.PrintToChat($"{chatPrefix} Skip veto command cannot be used if match Match has already started!");
                     }
                 }
                 else {

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -225,6 +225,30 @@ namespace MatchZy
             }
         }
 
+        [ConsoleCommand("css_skipveto", "Skips the current veto phase")]
+        [ConsoleCommand("css_sv", "Skips the current veto phase")]
+        public void OnSkipVetoCommand(CCSPlayerController? player, CommandInfo? command) {            
+            if (IsPlayerAdmin(player, "css_skipveto", "@css/config")) {
+                SkipVeto();
+                if (matchStarted) {
+                    if (player == null) {
+                        ReplyToUserCommand(player, $"Match has already started!");
+                    } else {
+                        player.PrintToChat($"{chatPrefix} Match has already started!");
+                    }
+                }
+                else {
+                    if (player == null) {
+                        ReplyToUserCommand(player, $"Veto phase has been cancelled!");
+                    } else {
+                        player.PrintToChat($"{chatPrefix} Veto phase has been cancelled!");
+                    }
+                }
+            } else {
+                SendPlayerNotAdminMessage(player);
+            }
+        }
+
         [ConsoleCommand("css_roundknife", "Toggles knife round for the match")]
         [ConsoleCommand("css_rk", "Toggles knife round for the match")]
         public void OnKnifeCommand(CCSPlayerController? player, CommandInfo? command) {            

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -229,7 +229,6 @@ namespace MatchZy
         [ConsoleCommand("css_sv", "Skips the current veto phase")]
         public void OnSkipVetoCommand(CCSPlayerController? player, CommandInfo? command) {            
             if (IsPlayerAdmin(player, "css_skipveto", "@css/config")) {
-                SkipVeto();
                 if (matchStarted) {
                     if (player == null) {
                         ReplyToUserCommand(player, $"Match has already started!");
@@ -238,6 +237,7 @@ namespace MatchZy
                     }
                 }
                 else {
+                    SkipVeto();
                     if (player == null) {
                         ReplyToUserCommand(player, $"Veto phase has been cancelled!");
                     } else {

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -126,6 +126,8 @@ namespace MatchZy
                 { ".rk", OnKnifeCommand },
                 { ".playout", OnPlayoutCommand },
                 { ".start", OnStartCommand },
+                { ".skipveto", OnSkipVetoCommand },
+                { ".sv", OnSkipVetoCommand },
                 { ".restart", OnRestartMatchCommand },
                 { ".reloadmap", OnMapReloadCommand },
                 { ".settings", OnMatchSettingsCommand },

--- a/Utility.cs
+++ b/Utility.cs
@@ -399,6 +399,15 @@ namespace MatchZy
             } 
         }
 
+        public void SkipVeto()
+        {
+            isWarmup = true;
+            readyAvailable = true;
+            isPreVeto = false;
+            isVeto = false;
+            StartWarmup();
+        }
+
         private void UpdatePlayersMap() {
             try
             {

--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -56,6 +56,7 @@ Most of the commands can also be used using ! prefix instead of . (like !ready)
 - `.forcepause` Pauses the match as an admin (Players cannot unpause the admin-paused match). (`.fp` for shorter command)
 - `.forceunpause` Force unpauses the match. (`.fup` for shorter command)
 - `.restore <round>` Restores the backup of provided round number.
+- `.skipveto` / `.sv` Skips the current veto phase.
 - `.roundknife` / `.rk` Toggles the knife round. If disabled, match will directly go from Warmup phase to Live phase.
 - `.playout` Toggles playout (If playout is enabled, all rounds would be played irrespective of winner. Useful in scrims!)
 - `.whitelist` Toggles whitelisting of players. To whitelist a player, add the steam64id in `cfg/MatchZy/whitelist.cfg`


### PR DESCRIPTION
To allow admins to skip the veto phase in case it is not required anymore. This can only be executed if the match has not started.