### PR TITLE
BUG: Fix captain selection on Map veto

### DIFF
--- a/MapVeto.cs
+++ b/MapVeto.cs
@@ -26,6 +26,7 @@ namespace MatchZy
 
         public void CreateVeto()
         {
+            SwapPlayersToTeams();
             vetoCaptains["team1"] = GetTeamCaptain("team1");
             vetoCaptains["team2"] = GetTeamCaptain("team2");
             // Todo: Implement pauseOnVeto CVAR
@@ -378,6 +379,15 @@ namespace MatchZy
             }
 
             return -1;
+        }
+
+        public void SwapPlayersToTeams()
+        {
+            foreach (var key in playerData.Keys)
+            {
+                if (!playerData[key].IsValid || playerData[key].IsBot) continue;
+                playerData[key].SwitchTeam(GetPlayerTeam(playerData[key]));
+            }
         }
 
         public string GetCurrentMapSelectionOption()

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -205,7 +205,7 @@ namespace MatchZy
             {
                 CCSPlayerController player = @event.Userid;
 
-                if (player.IsHLTV || player.IsBot || !isMatchSetup)
+                if (player.IsHLTV || player.IsBot || (!isMatchSetup && !isVeto))
                 {
                     return HookResult.Continue;
                 }
@@ -228,7 +228,7 @@ namespace MatchZy
 
             AddCommandListener("jointeam", (player, info) =>
             {
-                if (isMatchSetup && player != null && player.IsValid) {
+                if ((isMatchSetup || isVeto) && player != null && player.IsValid) {
                     if (int.TryParse(info.ArgByIndex(1), out int joiningTeam)) {
                         int playerTeam = (int)GetPlayerTeam(player);
                         if (joiningTeam != playerTeam) {


### PR DESCRIPTION
Discovered this bug when developing a fork. When a match is loaded, players are not swapped to their correct teams.
However, the map veto process assumes they are, so when the veto starts it will select captains based on in-game teams.

Example:
- Match loaded
- team1 is Terrorists
- team2 is CTs
- A player from team2 is current on the Terrorist team
- Map veto starts
- The team2 player that is currently on Terrorist is selected as the captain for team1 (wrong)

All this does is swap players to their correct teams and enforce jointeam restrictions during the veto process.