### PR TITLE
0.7.5 | BO2 and CFGs fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # MatchZy Changelog
 
+# 0.7.5
+
+#### April 27, 2024
+
+- Upgraded CounterStrikeSharp to v217
+- Fixed CFG execution on Map Start (After the latest update, CFGs were getting overriden by gamemodes cfg. Hence, added a timer to delay MatchZy's CFG execution on MapStart)
+- Fixed BO2 setup, now Get5 server will be freed once the BO2 match is over
+
 # 0.7.4
 
 #### April 26, 2024

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -13,7 +13,7 @@ namespace MatchZy
     {
 
         public override string ModuleName => "MatchZy";
-        public override string ModuleVersion => "0.7.4";
+        public override string ModuleVersion => "0.7.5";
 
         public override string ModuleAuthor => "WD- (https://github.com/shobhit-pathak/)";
 
@@ -287,13 +287,15 @@ namespace MatchZy
             // });
 
             RegisterListener<Listeners.OnMapStart>(mapName => { 
-                if (!isMatchSetup)
-                {
-                    AutoStart();
-                    return;
-                }
-                if (isWarmup) StartWarmup();
-                if (isPractice) StartPracticeMode();
+                AddTimer(1.0f, () => {
+                    if (!isMatchSetup)
+                    {
+                        AutoStart();
+                        return;
+                    }
+                    if (isWarmup) StartWarmup();
+                    if (isPractice) StartPracticeMode();
+                });
             });
 
             // RegisterListener<Listeners.OnMapEnd>(() => {

--- a/MatchZy.csproj
+++ b/MatchZy.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.215">
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.217">
         <PrivateAssets>none</PrivateAssets>
         <ExcludeAssets>runtime</ExcludeAssets>
         <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Utility.cs
+++ b/Utility.cs
@@ -726,7 +726,11 @@ namespace MatchZy
 
             int remainingMaps = matchConfig.NumMaps - matchzyTeam1.seriesScore - matchzyTeam2.seriesScore;
             Log($"[HandleMatchEnd] MATCH ENDED, remainingMaps: {remainingMaps}, NumMaps: {matchConfig.NumMaps}, Team1SeriesScore: {matchzyTeam1.seriesScore}, Team2SeriesScore: {matchzyTeam2.seriesScore}");
-            if (matchConfig.SeriesCanClinch) {
+            if (matchzyTeam1.seriesScore == matchzyTeam2.seriesScore && remainingMaps <= 0) 
+            {
+                EndSeries(null, restartDelay - 1);
+            }
+            else if (matchConfig.SeriesCanClinch) {
                 int mapsToWinSeries = (matchConfig.NumMaps / 2) + 1;
                 if (matchzyTeam1.seriesScore == mapsToWinSeries) {
                     EndSeries(winnerName, restartDelay - 1);


### PR DESCRIPTION
- Upgraded CounterStrikeSharp to v217
- Fixed CFG execution on Map Start (After the latest update, CFGs were getting overriden by gamemodes cfg. Hence, added a timer to delay MatchZy's CFG execution on MapStart)
- Fixed BO2 setup, now Get5 server will be freed once the BO2 match is over
