### PR TITLE
Prac: Remove freeze time and set round time to 60 minutes

### DIFF
--- a/cfg/MatchZy/prac.cfg
+++ b/cfg/MatchZy/prac.cfg
@@ -35,6 +35,9 @@ bot_quota_mode fill
 mp_solid_teammates 2
 mp_autoteambalance false
 mp_teammates_are_enemies false
+mp_freezetime 0
+mp_roundtime 60
+mp_roundtime_defuse 60
 buddha 1
 buddha_ignore_bots 1
 buddha_reset_hp 100


### PR DESCRIPTION
Freezetime and roundtime is set for the other modes, but not for prac
I've set the timers for common values for prac servers (No freezetime and 1h round time).

Given this mod implements dry mode along with prac mode, it seems ideal to have infinite prac time, and run timing/tests using the dry mode.