### PR TITLE
0.7.10 | Colored smokes, best/worst spawn and other prac mprovements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # MatchZy Changelog
 
+# 0.7.10
+
+#### May 19, 2024
+
+- Added `matchzy_smoke_color_enabled` config convar for practice mode which changes the smoke's color to player's team color (player's color seen in the radar)
+- Added `.bestspawn` command which teleports you to your team's closest spawn from your current position
+- Added `.worstspawn` command which teleports you to your team's furthest spawn from your current position
+- Added `.bestctspawn` command which teleports you to CT team's closest spawn from your current position
+- Added `.worstctspawn` command which teleports you to CT team's furthest spawn from your current position
+- Added `.besttspawn` command which teleports you to T team's closest spawn from your current position
+- Added `.worsttspawn` command which teleports you to T team's furthest spawn from your current position
+- Practice mode will no longer have `warmup` help text.
+
 # 0.7.9
 
 #### May 06, 2024

--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -11,6 +11,7 @@ namespace MatchZy
     public partial class MatchZy
     {
 
+        public FakeConVar<bool> smokeColorEnabled = new("matchzy_smoke_color_enabled", "Whether player-specific smoke color is enabled or not. Default: false", false);
         public FakeConVar<bool> techPauseEnabled = new("matchzy_enable_tech_pause", "Whether .tech command is enabled or not. Default: true", true);
         public FakeConVar<int> techPauseDuration  = new("matchzy_tech_pause_duration", "Tech pause duration in seconds. Default value: 300", 300);
 

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -234,6 +234,12 @@ public partial class MatchZy
                 }
 
                 lastGrenadeThrownTime[(int)projectile.Index] = DateTime.Now;
+                if (smokeColorEnabled.Value && nadeType == "smoke")
+                {
+                    CSmokeGrenadeProjectile smokeProjectile = new(entity.Handle);
+                    smokeProjectile.SmokeColor.X = GetPlayerTeammateColor(player).R;
+                    smokeProjectile.SmokeColor.Y = GetPlayerTeammateColor(player).G;
+                }
             });
         }
         catch (Exception e)

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -13,7 +13,7 @@ namespace MatchZy
     {
 
         public override string ModuleName => "MatchZy";
-        public override string ModuleVersion => "0.7.9";
+        public override string ModuleVersion => "0.7.10";
 
         public override string ModuleAuthor => "WD- (https://github.com/shobhit-pathak/)";
 
@@ -109,7 +109,7 @@ namespace MatchZy
                 { ".r", OnPlayerReady },
                 { ".forceready", OnForceReadyCommandCommand },
                 { ".unready", OnPlayerUnReady },
-		{ ".notready", OnPlayerUnReady },
+                { ".notready", OnPlayerUnReady },
                 { ".ur", OnPlayerUnReady },
                 { ".stay", OnTeamStay },
                 { ".switch", OnTeamSwitch },
@@ -186,7 +186,13 @@ namespace MatchZy
                 { ".throwmolotov", OnRethrowMolotovCommand },
                 { ".rethrowmolotov", OnRethrowMolotovCommand },
                 { ".timer", OnTimerCommand },
-                { ".lastindex", OnLastIndexCommand }
+                { ".lastindex", OnLastIndexCommand },
+                { ".bestspawn", OnBestSpawnCommand },
+                { ".worstspawn", OnWorstSpawnCommand },
+                { ".bestctspawn", OnBestCTSpawnCommand },
+                { ".worstctspawn", OnWorstCTSpawnCommand },
+                { ".besttspawn", OnBestTSpawnCommand },
+                { ".worsttspawn", OnWorstTSpawnCommand }
             };
 
             RegisterEventHandler<EventPlayerConnectFull>(EventPlayerConnectFullHandler);

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -134,7 +134,7 @@ namespace MatchZy
                 { ".sv", OnSkipVetoCommand },
                 { ".restart", OnRestartMatchCommand },
                 { ".endmatch", OnEndMatchCommand },
-		        { ".forceend", OnEndMatchCommand },
+                { ".forceend", OnEndMatchCommand },
                 { ".reloadmap", OnMapReloadCommand },
                 { ".settings", OnMatchSettingsCommand },
                 { ".whitelist", OnWLCommand },

--- a/MatchZy.csproj
+++ b/MatchZy.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.228">
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.233">
         <PrivateAssets>none</PrivateAssets>
         <ExcludeAssets>runtime</ExcludeAssets>
         <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -1535,6 +1535,88 @@ namespace MatchZy
             PrintToAllChat($"sv_grenade_trajectory_prac_pipreview is now set to {!trajValue}");
         }
 
+        [ConsoleCommand("css_bestspawn", "Teleports you to your team's closest spawn from your current position")]
+        public void OnBestSpawnCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (!isPractice || !IsPlayerValid(player)) return;
+            TeleportPlayerToBestSpawn(player!, player!.TeamNum);
+        }
+
+        [ConsoleCommand("css_worstspawn", "Teleports you to your team's furthest spawn from your current position")]
+        public void OnWorstSpawnCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (!isPractice || !IsPlayerValid(player)) return;
+            TeleportPlayerToWorstSpawn(player!, player!.TeamNum);
+        }
+
+        [ConsoleCommand("css_bestctspawn", "Teleports you to CT team's closest spawn from your current position")]
+        public void OnBestCTSpawnCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (!isPractice || !IsPlayerValid(player)) return;
+            TeleportPlayerToBestSpawn(player!, (byte)CsTeam.CounterTerrorist);
+        }
+
+        [ConsoleCommand("css_worstctspawn", "Teleports you to CT team's furthest spawn from your current position")]
+        public void OnWorstCTSpawnCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (!isPractice || !IsPlayerValid(player)) return;
+            TeleportPlayerToWorstSpawn(player!, (byte)CsTeam.CounterTerrorist);
+        }
+
+        [ConsoleCommand("css_besttspawn", "Teleports you to T team's closest spawn from your current position")]
+        public void OnBestTSpawnCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (!isPractice || !IsPlayerValid(player)) return;
+            TeleportPlayerToBestSpawn(player!, (byte)CsTeam.Terrorist);
+        }
+
+        [ConsoleCommand("css_worsttspawn", "Teleports you to T team's furthest spawn from your current position")]
+        public void OnWorstTSpawnCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (!isPractice || !IsPlayerValid(player)) return;
+            TeleportPlayerToWorstSpawn(player!, (byte)CsTeam.Terrorist);
+        }
+
+        public void TeleportPlayerToBestSpawn(CCSPlayerController player, byte teamNum)
+        {
+            if (!spawnsData.TryGetValue(teamNum, out List<Position>? teamSpawns)) return;
+            Vector playerPosition = player!.PlayerPawn!.Value!.CBodyComponent!.SceneNode!.AbsOrigin;
+            int closestIndex = -1;
+            double minDistance = double.MaxValue;
+            for (int index = 0; index < teamSpawns.Count; index++)
+            {
+                Vector spawnPosition = teamSpawns[index].PlayerPosition;
+                Vector diff = playerPosition - spawnPosition;
+                float distance = diff.Length();
+                if (distance < minDistance)
+                {
+                    minDistance = distance;
+                    closestIndex = index;
+                }
+            }
+            player!.PlayerPawn.Value!.Teleport(teamSpawns[closestIndex].PlayerPosition, teamSpawns[closestIndex].PlayerAngle, new Vector(0, 0, 0));
+        }
+
+        public void TeleportPlayerToWorstSpawn(CCSPlayerController player, byte teamNum)
+        {
+            if (!spawnsData.TryGetValue(teamNum, out List<Position>? teamSpawns)) return;
+            Vector playerPosition = player!.PlayerPawn!.Value!.CBodyComponent!.SceneNode!.AbsOrigin;
+            int farthestIndex = -1;
+            double maxDistance = double.MinValue;
+            for (int index = 0; index < teamSpawns.Count; index++)
+            {
+                Vector spawnPosition = teamSpawns[index].PlayerPosition;
+                Vector diff = playerPosition - spawnPosition;
+                float distance = diff.Length();
+                if (distance > maxDistance)
+                {
+                    maxDistance = distance;
+                    farthestIndex = index;
+                }
+            }
+            player!.PlayerPawn.Value!.Teleport(teamSpawns[farthestIndex].PlayerPosition, teamSpawns[farthestIndex].PlayerAngle, new Vector(0, 0, 0));
+        }
+
         // Todo: Implement timer2 when we have OnPlayerRunCmd in CS#. Using OnTick would be its alternative, but it would be very expensive and not worth it.
         // [ConsoleCommand("css_timer2", "Starts a timer, use .timer2 again to stop it.")]
         // public void OnTimer2Command(CCSPlayerController? player, CommandInfo command)

--- a/Utility.cs
+++ b/Utility.cs
@@ -10,6 +10,7 @@ using CounterStrikeSharp.API.Modules.Admin;
 using System.Text.RegularExpressions;
 using System.Text;
 using Newtonsoft.Json.Linq;
+using System.Drawing;
 
 
 namespace MatchZy
@@ -1578,6 +1579,19 @@ namespace MatchZy
                 player.PlayerPawn.IsValid &&
                 player.PlayerPawn.Value != null
             );
+        }
+
+        public static Color GetPlayerTeammateColor(CCSPlayerController playerController)
+        {
+            return playerController.CompTeammateColor switch
+            {
+                1 => Color.FromArgb(50, 255, 0),
+                2 => Color.FromArgb(255, 255, 0),
+                3 => Color.FromArgb(255, 132, 0),
+                4 => Color.FromArgb(255, 0, 255),
+                0 => Color.FromArgb(0, 187, 255),
+                _ => Color.Red,
+            };
         }
     }
 }

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -91,5 +91,8 @@ matchzy_allow_force_ready true
 // Maximum number of grenade history that may be saved per-map, per-client. Set to 0 to disable the limit and allow unlimited grenades to be stored. Default value: 512
 matchzy_max_saved_last_grenades 512
 
+// Whether player-specific smoke color is enabled or not. Default: false
+matchzy_smoke_color_enabled false
+
 // If set to true, all the players will have admin privilege. Default: false
 matchzy_everyone_is_admin false

--- a/cfg/MatchZy/prac.cfg
+++ b/cfg/MatchZy/prac.cfg
@@ -30,14 +30,11 @@ mp_ct_default_primary               "weapon_m4a1"
 mp_t_default_grenades               "weapon_molotov weapon_hegrenade weapon_smokegrenade weapon_flashbang weapon_decoy"
 mp_t_default_primary                "weapon_ak47"
 mp_warmup_end
-mp_roundtime_defuse 60
-mp_roundtime 60
 mp_buytime 999999
 mp_buy_allow_grenades 1
 mp_respawn_on_death_ct true
 mp_respawn_on_death_t true
 mp_team_intro_time 0
-mp_freezetime 0
 bot_quota_mode fill
 mp_solid_teammates 2
 mp_autoteambalance false

--- a/cfg/MatchZy/prac.cfg
+++ b/cfg/MatchZy/prac.cfg
@@ -14,7 +14,8 @@ weapon_auto_cleanup_time            "15"
 weapon_max_before_cleanup           "30"        
 mp_buy_anywhere                     "1"         
 mp_maxmoney                         "9999999"   
-mp_startmoney                       "9999999"   
+mp_startmoney                       "9999999"
+mp_afterroundmoney                  "9999999"
 mp_weapons_allow_typecount          "-1"        
 mp_death_drop_breachcharge          "false"     
 mp_death_drop_defuser               "false"    
@@ -28,9 +29,15 @@ mp_ct_default_grenades              "weapon_incgrenade weapon_hegrenade weapon_s
 mp_ct_default_primary               "weapon_m4a1"
 mp_t_default_grenades               "weapon_molotov weapon_hegrenade weapon_smokegrenade weapon_flashbang weapon_decoy"
 mp_t_default_primary                "weapon_ak47"
-mp_warmup_online_enabled            "true"      
-mp_warmup_pausetimer                "1"         
-mp_warmup_start
+mp_warmup_end
+mp_roundtime_defuse 60
+mp_roundtime 60
+mp_buytime 999999
+mp_buy_allow_grenades 1
+mp_respawn_on_death_ct true
+mp_respawn_on_death_t true
+mp_team_intro_time 0
+mp_freezetime 0
 bot_quota_mode fill
 mp_solid_teammates 2
 mp_autoteambalance false
@@ -38,3 +45,4 @@ mp_teammates_are_enemies false
 buddha 1
 buddha_ignore_bots 1
 buddha_reset_hp 100
+mp_restartgame 1

--- a/documentation/docs/commands.md
+++ b/documentation/docs/commands.md
@@ -18,6 +18,12 @@ Most of the commands can also be used using ! prefix instead of . (like !ready)
 - `.spawn <number>` Spawns to the provided competitive spawn number of same team
 - `.ctspawn <number>` Spawns to the provided competitive spawn number of CT
 - `.tspawn <number>` Spawns to the provided competitive spawn number of T
+- `.bestspawn` Teleports you to your team's closest spawn from your current position
+- `.worstspawn` Teleports you to your team's furthest spawn from your current position
+- `.bestctspawn` Teleports you to CT team's closest spawn from your current position
+- `.worstctspawn` Teleports you to CT team's furthest spawn from your current position
+- `.besttspawn` Teleports you to T team's closest spawn from your current position
+- `.worsttspawn` Teleports you to T team's furthest spawn from your current position
 - `.bot` Adds a bot on user's current position
 - `.crouchbot` Adds a crouched bot on user's current position (Alias: `.cbot`)
 - `.boost` Adds a bot on current position and boosts player on it

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -111,6 +111,9 @@ Example: `matchzy_demo_upload_url "https://your-website.com/upload-endpoint"` <b
 ####`matchzy_max_saved_last_grenades`
 :   Maximum number of grenade history that may be saved per-map, per-client. Set to 0 to disable the limit and allow unlimited grenades to be stored.<br>**`Default: 512`**
 
+####`matchzy_smoke_color_enabled`
+:   If enabled, the smoke's color will be changed to player's team color (player's color seen in the radar) .<br>**`Default: false`**
+
 ####`matchzy_everyone_is_admin`
 :   If set to true, everyone will be granted admin permissions for MatchZy.<br>**`Default: false`**
 
@@ -164,7 +167,7 @@ There is a scope of improvement here, like having the match score in the CSV fil
 ## Events and HTTP Logging
 
 ####`matchzy_remote_log_url`
-:   The URL to send all [events](../events_and_forwards) to (POST request). Set to empty string to disable.<br>**`Default: ""`**<br>Usage: `matchzy_remote_log_url "url"`<br>Alias: `get5_remote_log_url`
+:   The URL to send all [events](../events_and_forwards) to (POST request). Set to empty string to disable. [OpenAPI Doc for the events](events.html)<br>**`Default: ""`**<br>Usage: `matchzy_remote_log_url "url"`<br>Alias: `get5_remote_log_url`
 
 ####`matchzy_remote_log_header_key`
 :   If this and matchzy_remote_log_header_value are defined, this header name and value will be added in your [HTTP Post requests'](../events_and_forwards) header.<br>**`Default: ""`**<br>Usage: `matchzy_remote_log_header_key "Authorization"`<br>Alias: `get5_remote_log_header_key`

--- a/documentation/docs/developers.md
+++ b/documentation/docs/developers.md
@@ -1,8 +1,8 @@
-Since this plugin is built on C#, [.NET 7.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) will be required if you intend to make changes in this plugin. Once you have that installed,
+Since this plugin is built on C#, [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) will be required if you intend to make changes in this plugin. Once you have that installed,
 
 1. Clone the repository
 2. Use `dotnet restore` to restore and install the dependencies.
 3. Make your changes
 4. Use `dotnet publish` command and you'll get a folder called `bin` in your plugin directory.
-5. Navigate to `bin/Debug/net7.0/publish/`and copy all the content from there and paste it into `csgo/addons/counterstrikesharp/plugins/MatchZy` (CounterStrikeSharp.API.dll and CounterStrikeSharp.API.pdb can be skipped)
+5. Navigate to `bin/Release/net8.0/publish/`and copy all the content from there and paste it into `csgo/addons/counterstrikesharp/plugins/MatchZy` (CounterStrikeSharp.API.dll and CounterStrikeSharp.API.pdb can be skipped)
 6. It's done! Now you can test your changes, and also contribute to the plugin if you want to :p 


### PR DESCRIPTION
- Added `matchzy_smoke_color_enabled` config convar for practice mode which changes the smoke's color to player's team color (player's color seen in the radar)
- Added `.bestspawn` command which teleports you to your team's closest spawn from your current position
- Added `.worstspawn` command which teleports you to your team's furthest spawn from your current position
- Added `.bestctspawn` command which teleports you to CT team's closest spawn from your current position
- Added `.worstctspawn` command which teleports you to CT team's furthest spawn from your current position
- Added `.besttspawn` command which teleports you to T team's closest spawn from your current position
- Added `.worsttspawn` command which teleports you to T team's furthest spawn from your current position
- Practice mode will no longer have `warmup` help text.