### PR TITLE
0.7.11 | Improved help, fixed overtime and other improvements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed overtime getting automatically enabled even if turned off in `live.cfg`
 - Added `matchzy_show_credits_on_match_start` config convar to toggle 'MatchZy Plugin by WD-' message on match start.
 - Added gradient while printing `KNIFE!` and `LIVE!` message.
+- Added `.pip` alias for `.traj` command to toggle `sv_grenade_trajectory_prac_pipreview` in practice mode.
 
 # 0.7.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # MatchZy Changelog
 
+# 0.7.11
+
+#### May 19, 2024
+
+- Improved `.help` command with better readability and updated commands
+- Fixed overtime getting automatically enabled even if turned off in `live.cfg`
+- Added `matchzy_show_credits_on_match_start` config convar to toggle 'MatchZy Plugin by WD-' message on match start.
+- Added gradient while printing `KNIFE!` and `LIVE!` message.
+
 # 0.7.10
 
 #### May 19, 2024

--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -19,6 +19,8 @@ namespace MatchZy
 
         public FakeConVar<bool> everyoneIsAdmin = new("matchzy_everyone_is_admin", "If set to true, all the players will have admin privilege. Default: false", false);
 
+        public FakeConVar<bool> showCreditsOnMatchStart = new("matchzy_show_credits_on_match_start", "Whether to show 'MatchZy Plugin by WD-' message on match start. Default: true", true);
+
         [ConsoleCommand("matchzy_whitelist_enabled_default", "Whether Whitelist is enabled by default or not. Default value: false")]
         public void MatchZyWLConvar(CCSPlayerController? player, CommandInfo command)
         {

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -499,14 +499,8 @@ namespace MatchZy
                     // player.PrintToChat($"{chatPrefix} Playout is now {ChatColors.Green}{playoutStatus}{ChatColors.Default}!");
                     PrintToPlayerChat(player, Localizer["matchzy.cc.playout", playoutStatus]);
                 }
-                
-                if (isPlayOutEnabled) {
-                    Server.ExecuteCommand("mp_overtime_enable 0");
-                    Server.ExecuteCommand("mp_match_can_clinch false");
-                } else {
-                    Server.ExecuteCommand("mp_match_can_clinch true");
-                    Server.ExecuteCommand("mp_overtime_enable 1");
-                }
+
+                HandlePlayoutConfig();
                 
             } else {
                 SendPlayerNotAdminMessage(player);

--- a/MatchManagement.cs
+++ b/MatchManagement.cs
@@ -607,5 +607,19 @@ namespace MatchZy
             });
         }
 
+        public void HandlePlayoutConfig()
+        {
+            if (isPlayOutEnabled) {
+                Server.ExecuteCommand("mp_overtime_enable 0");
+                Server.ExecuteCommand("mp_match_can_clinch false");
+            } else {
+                var absoluteCfgPath = Path.Join(Server.GameDirectory + "/csgo/cfg", GetGameMode() == 1 ? liveCfgPath : liveWingmanCfgPath);
+                string? matchCanClinch = GetConvarValueFromCFGFile(absoluteCfgPath, "mp_match_can_clinch");
+                string? overtimeEnabled = GetConvarValueFromCFGFile(absoluteCfgPath, "mp_overtime_enable");
+                Server.ExecuteCommand($"mp_match_can_clinch {matchCanClinch ?? "1"}");
+                Server.ExecuteCommand($"mp_overtime_enable {overtimeEnabled ?? "1"}");
+            }
+        }
+
     }
 }

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -156,6 +156,7 @@ namespace MatchZy
                 { ".solid", OnSolidCommand },
                 { ".impacts", OnImpactsCommand },
                 { ".traj", OnTrajCommand },
+                { ".pip", OnTrajCommand },
                 { ".god", OnGodCommand },
                 { ".ff", OnFastForwardCommand },
                 { ".fastforward", OnFastForwardCommand },

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -13,7 +13,7 @@ namespace MatchZy
     {
 
         public override string ModuleName => "MatchZy";
-        public override string ModuleVersion => "0.7.10";
+        public override string ModuleVersion => "0.7.11";
 
         public override string ModuleAuthor => "WD- (https://github.com/shobhit-pathak/)";
 

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -106,11 +106,12 @@ namespace MatchZy
             }
             GetSpawns();
             PrintToAllChat($"Practice mode loaded!");
-            PrintToAllChat($"Available commands:");
-            PrintToAllChat($".spawn, .ctspawn, .tspawn, .bot, .nobots, .dryrun, .noflash, .break, .exitprac");
-            PrintToAllChat($".loadnade <name>, .savenade <name>, .importnade <code>, .listnades <optional filter>");
-            PrintToAllChat($".listnades <optional filter>, .delnade <name>, .globalnades");
-            PrintToAllChat($".rethrow, .throwindex <index>, .lastindex, .last, .back <number>, .delay <number>");
+            Server.PrintToChatAll($" {ChatColors.Green}Spawns: {ChatColors.Default}.spawn, .ctspawn, .tspawn, .bestspawn, .worstspawn");
+            Server.PrintToChatAll($" {ChatColors.Green}Bots: {ChatColors.Default}.bot, .nobots, .crouchbot, .boost, .crouchboost");
+            Server.PrintToChatAll($" {ChatColors.Green}Nades: {ChatColors.Default}.loadnade, .savenade, .importnade, .listnades");
+            Server.PrintToChatAll($" {ChatColors.Green}Nade Throw: {ChatColors.Default}.rethrow, .throwindex <index>, .lastindex, .delay <number>");
+            Server.PrintToChatAll($" {ChatColors.Green}Utility & Toggles: {ChatColors.Default}.clear, .fastforward, .last, .back, .solid, .impacts, .traj");
+            Server.PrintToChatAll($" {ChatColors.Green}Sides & Others: {ChatColors.Default}.ct, .t, .spec, .fas, .god, .dryrun, .break, .exitprac");
         }
 
         public void GetSpawns()

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -1525,6 +1525,7 @@ namespace MatchZy
         }
 
         [ConsoleCommand("css_traj", "Toggles sv_grenade_trajectory_prac_pipreview in practice mode")]
+        [ConsoleCommand("css_pip", "Toggles sv_grenade_trajectory_prac_pipreview in practice mode")]
         public void OnTrajCommand(CCSPlayerController? player, CommandInfo? command)
         {
             if (!isPractice || !IsPlayerValid(player)) return;

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -96,3 +96,6 @@ matchzy_smoke_color_enabled false
 
 // If set to true, all the players will have admin privilege. Default: false
 matchzy_everyone_is_admin false
+
+// Whether to show 'MatchZy Plugin by WD-' message on match start. Default: true
+matchzy_show_credits_on_match_start true

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -117,6 +117,9 @@ Example: `matchzy_demo_upload_url "https://your-website.com/upload-endpoint"` <b
 ####`matchzy_everyone_is_admin`
 :   If set to true, everyone will be granted admin permissions for MatchZy.<br>**`Default: false`**
 
+####`matchzy_show_credits_on_match_start`
+:   Whether to show 'MatchZy Plugin by WD-' message on match start.<br>**`Default: true`**
+
 ### Configuring Warmup/Knife/Live/Prac CFGs
 Again, inside `csgo/cfg/MatchZy`, files named `warmup.cfg`, `knife.cfg`, `live.cfg` and `prac.cfg` should be present. These configs are executed when Warmup, Knife, Live and Practice Mode is started respectively.
 


### PR DESCRIPTION
- Improved `.help` command with better readability and updated commands
- Fixed overtime getting automatically enabled even if turned off in `live.cfg`
- Added `matchzy_show_credits_on_match_start` config convar to toggle 'MatchZy Plugin by WD-' message on match start.
- Added gradient while printing `KNIFE!` and `LIVE!` message.
- Added `.pip` alias for `.traj` command to toggle `sv_grenade_trajectory_prac_pipreview` in practice mode.