### PR TITLE
Fix SendEventAsync: Post fails when header is not empty with empty value

### DIFF
--- a/PublishEvents.cs
+++ b/PublishEvents.cs
@@ -21,7 +21,7 @@ namespace MatchZy
 
                 Log($"[SendEventAsync] SENDING DATA: {jsonString}");
 
-                if (!string.IsNullOrEmpty(matchConfig.RemoteLogHeaderKey))
+                if (!string.IsNullOrEmpty(matchConfig.RemoteLogHeaderKey) && !string.IsNullOrEmpty(matchConfig.RemoteLogHeaderValue))
                 {
                     httpClient.DefaultRequestHeaders.Add(matchConfig.RemoteLogHeaderKey, matchConfig.RemoteLogHeaderValue);
                 }


### PR DESCRIPTION
Hello, I was trying out something with webhook API and found out there is a bug on SendEventAsync.

```
Jun 23 00:38:36:  [MatchZy] [SendEventAsync] Sending Event: going_live for matchId: 3 mapNumber: 0 on https://[URL HIDDEN FOR PRIVACY]/get5/event
Jun 23 00:38:36:  [MatchZy] [SendEventAsync] SENDING DATA: {"map_number":0,"matchid":"3","event":"going_live"}
Jun 23 00:38:36:  [MatchZy] [SendEventAsync FATAL] An error occurred: The format of value '' is invalid.
```

cvars:
```
matchzy_remote_log_header_key "Authorization"
matchzy_remote_log_header_value ""
```

C# http fails on invalid value(such as empty string) for request header, so I fixed them :)
fyi: https://stackoverflow.com/questions/13198090/adding-httpclient-headers-generates-a-formatexception-with-some-values