### PR TITLE
Make MatchID int ( #164 )

### DIFF
--- a/Events.cs
+++ b/Events.cs
@@ -15,7 +15,7 @@ public class MatchZyEvent
 public class MatchZyMatchEvent : MatchZyEvent
 {
     [JsonPropertyName("matchid")]
-    public required string MatchId { get; init; }
+    public required long MatchId { get; init; }
 
     protected MatchZyMatchEvent(string eventName) : base(eventName)
     {

--- a/MapVeto.cs
+++ b/MapVeto.cs
@@ -252,7 +252,7 @@ namespace MatchZy
 
             var mapPickedEvent = new MatchZyMapPickedEvent
             {
-                MatchId = liveMatchId.ToString(),
+                MatchId = liveMatchId,
                 MapName = mapRemovedName,
                 MapNumber = matchConfig.Maplist.Count,
                 Team = (matchzyTeam == matchzyTeam1) ? "team1" : "team2",
@@ -282,7 +282,7 @@ namespace MatchZy
 
             var mapMapVetoedEvent = new MatchZyMapVetoedEvent
             {
-                MatchId = liveMatchId.ToString(),
+                MatchId = liveMatchId,
                 MapName = mapRemovedName,
                 Team = (matchzyTeam == matchzyTeam1) ? "team1" : "team2",
             };
@@ -533,7 +533,7 @@ namespace MatchZy
 
             var sidePickedEvent = new MatchZySidePickedEvent
             {
-                MatchId = liveMatchId.ToString(),
+                MatchId = liveMatchId,
                 MapName = mapName,
                 MapNumber = matchConfig.Maplist.Count,
                 Team = (matchzyTeam == matchzyTeam1) ? "team1" : "team2",

--- a/MatchManagement.cs
+++ b/MatchManagement.cs
@@ -370,7 +370,7 @@ namespace MatchZy
 
             var seriesStartedEvent = new MatchZySeriesStartedEvent
             {
-                MatchId = liveMatchId.ToString(),
+                MatchId = liveMatchId,
                 NumberOfMaps = matchConfig.NumMaps,
                 Team1 = new(matchzyTeam1.id, matchzyTeam1.teamName),
                 Team2 = new(matchzyTeam2.id, matchzyTeam2.teamName),
@@ -586,7 +586,7 @@ namespace MatchZy
 
             var seriesResultEvent = new MatchZySeriesResultEvent()
             {
-                MatchId = matchId.ToString(),
+                MatchId = matchId,
                 Winner = new Winner(t1score > t2score && reverseTeamSides["CT"] == matchzyTeam1 ? "3" : "2", winnerTeam),
                 Team1SeriesScore = team1Score,
                 Team2SeriesScore = team2Score,

--- a/Utility.cs
+++ b/Utility.cs
@@ -252,7 +252,7 @@ namespace MatchZy
 
             var goingLiveEvent = new GoingLiveEvent
             {
-                MatchId = liveMatchId.ToString(),
+                MatchId = liveMatchId,
                 MapNumber = matchConfig.CurrentMapNumber,
             };
 
@@ -693,7 +693,7 @@ namespace MatchZy
 
             var mapResultEvent = new MapResultEvent
             {
-                MatchId = liveMatchId.ToString(),
+                MatchId = liveMatchId,
                 MapNumber = currentMapNumber,
                 Winner = new Winner(t1score > t2score && reverseTeamSides["CT"] == matchzyTeam1 ? "3" : "2", team1SeriesScore > team2SeriesScore ? "team1" : "team2"),
                 StatsTeam1 = new MatchZyStatsTeam(matchzyTeam1.id, matchzyTeam1.teamName, team1SeriesScore, t1score, 0, 0, new List<StatsPlayer>()),
@@ -904,7 +904,7 @@ namespace MatchZy
 
                     var roundEndEvent = new MatchZyRoundEndedEvent
                     {
-                        MatchId = liveMatchId.ToString(),
+                        MatchId = liveMatchId,
                         MapNumber = matchConfig.CurrentMapNumber,
                         RoundNumber = GetRoundNumer(),
                         Reason = @event.Reason,

--- a/documentation/docs/event_schema.yml
+++ b/documentation/docs/event_schema.yml
@@ -241,9 +241,9 @@ components:
         - type: object
           properties:
             matchid:
-              type: string
+              type: integer
               description: The ID of the match.
-              example: '14272'
+              example: 14272
     MatchZyMatchTeamEvent:
       allOf:
         - "$ref": "#/components/schemas/MatchZyMatchEvent"

--- a/documentation/docs/match_setup.md
+++ b/documentation/docs/match_setup.md
@@ -19,7 +19,7 @@ There are 2 commands available which can be used to load a match:
 
 ```json title="csgo/astralis_vs_navi_27.json"
 {
-  "matchid": "27",
+  "matchid": 27,
   "team1": {
     "name": "Astralis",
     "players": {


### PR DESCRIPTION
context: #164 

Originally get5 matchid WAS int, and supported string afterwards.

Now MatchZy only supports integer, However its definitions is string so I fixed them :)