### PR TITLE
Fix `.last` grenade's player rotation

### DIFF
--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -220,7 +220,7 @@ public partial class MatchZy
                     angle, 
                     velocity, 
                     player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin, 
-                    player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsRotation, 
+                    player.PlayerPawn.Value.EyeAngles,
                     nadeType,
                     DateTime.Now
                 );


### PR DESCRIPTION
Fix `.last` lineup rotation.

Now it will properly teleport the player aiming to the correct angle