### PR TITLE
feat: allow switching maps without prefixing "de_"

### DIFF
--- a/Utility.cs
+++ b/Utility.cs
@@ -513,6 +513,10 @@ namespace MatchZy
                 return;
             }
 
+            if (!mapName.Contains("_")) {
+                mapName = "de_" + mapName;
+            }
+
             if (long.TryParse(mapName, out _)) { // Check if mapName is a long for workshop map ids
                 Server.ExecuteCommand($"bot_kick");
                 Server.ExecuteCommand($"host_workshop_map \"{mapName}\"");


### PR DESCRIPTION
- Added support for `.map` command to automatically add the `de_` prefix if omitted. Non-de_ maps, like `cs_office`, still require the full prefix.

![image](https://github.com/user-attachments/assets/3ee0ac67-3fd3-4064-ae21-aeba3eaf858c)
