### PR TITLE
Fix segmentation fault on map switch after in-game veto

### DIFF
--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -11,53 +11,74 @@ namespace MatchZy
     {
         [ConsoleCommand("css_whitelist", "Toggles Whitelisting of players")]
         [ConsoleCommand("css_wl", "Toggles Whitelisting of players")]
-        public void OnWLCommand(CCSPlayerController? player, CommandInfo? command) {            
-            if (IsPlayerAdmin(player, "css_whitelist", "@css/config")) {
+        public void OnWLCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (IsPlayerAdmin(player, "css_whitelist", "@css/config"))
+            {
                 isWhitelistRequired = !isWhitelistRequired;
                 string WLStatus = isWhitelistRequired ? Localizer["matchzy.cc.enabled"] : Localizer["matchzy.cc.disabled"];
-                if (player == null) {
+                if (player == null)
+                {
                     //ReplyToUserCommand(player, $"Whitelist is now {WLStatus}!");
                     ReplyToUserCommand(player, Localizer["matchzy.cc.wl", WLStatus]);
-                } else {
+                }
+                else
+                {
                     //player.PrintToChat($"{chatPrefix} Whitelist is now {ChatColors.Green}{WLStatus}{ChatColors.Default}!");
                     PrintToPlayerChat(player, Localizer["matchzy.cc.wl", WLStatus]);
                 }
-            } else {
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
 
         [ConsoleCommand("css_save_nades_as_global", "Toggles Global Lineups for players")]
-        public void OnSaveNadesAsGlobalCommand(CCSPlayerController? player, CommandInfo? command) {            
-            if (IsPlayerAdmin(player, "css_save_nades_as_global", "@css/config")) {
+        public void OnSaveNadesAsGlobalCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (IsPlayerAdmin(player, "css_save_nades_as_global", "@css/config"))
+            {
                 isSaveNadesAsGlobalEnabled = !isSaveNadesAsGlobalEnabled;
                 string GlobalNadesStatus = isSaveNadesAsGlobalEnabled ? Localizer["matchzy.cc.enabled"] : Localizer["matchzy.cc.disabled"];
-                if (player == null) {
+                if (player == null)
+                {
                     //ReplyToUserCommand(player, $"Saving/Loading Lineups Globally is now {GlobalNadesStatus}!");
                     ReplyToUserCommand(player, Localizer["matchzy.cc.globalnades", GlobalNadesStatus]);
-                } else {
+                }
+                else
+                {
                     //player.PrintToChat($"{chatPrefix} Saving/Loading Lineups Globally is now {ChatColors.Green}{GlobalNadesStatus}{ChatColors.Default}!");
                     PrintToPlayerChat(player, Localizer["matchzy.cc.globalnades", GlobalNadesStatus]);
 
                 }
-            } else {
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
-        
+
         [ConsoleCommand("css_ready", "Marks the player ready")]
-        public void OnPlayerReady(CCSPlayerController? player, CommandInfo? command) {
+        public void OnPlayerReady(CCSPlayerController? player, CommandInfo? command)
+        {
             if (player == null) return;
             Log($"[!ready command] Sent by: {player.UserId} readyAvailable: {readyAvailable} matchStarted: {matchStarted}");
-            if (readyAvailable && !matchStarted) {
-                if (player.UserId.HasValue) {
-                    if (!playerReadyStatus.ContainsKey(player.UserId.Value)) {
+            if (readyAvailable && !matchStarted)
+            {
+                if (player.UserId.HasValue)
+                {
+                    if (!playerReadyStatus.ContainsKey(player.UserId.Value))
+                    {
                         playerReadyStatus[player.UserId.Value] = false;
                     }
-                    if (playerReadyStatus[player.UserId.Value]) {
+                    if (playerReadyStatus[player.UserId.Value])
+                    {
                         // player.PrintToChat($"{chatPrefix} You are already ready!");
                         PrintToPlayerChat(player, Localizer["matchzy.ready.markedready"]);
-                    } else {
+                    }
+                    else
+                    {
                         playerReadyStatus[player.UserId.Value] = true;
                         // player.PrintToChat($"{chatPrefix} {Localizer["matchzy.youareready"]}");
                         PrintToPlayerChat(player, Localizer["matchzy.ready.markedready"]);
@@ -70,17 +91,24 @@ namespace MatchZy
 
         [ConsoleCommand("css_unready", "Marks the player unready")]
         [ConsoleCommand("css_notready", "Marks the player unready")]
-        public void OnPlayerUnReady(CCSPlayerController? player, CommandInfo? command) {
+        public void OnPlayerUnReady(CCSPlayerController? player, CommandInfo? command)
+        {
             if (player == null) return;
             Log($"[!unready command] {player.UserId}");
-            if (readyAvailable && !matchStarted) {
-                if (player.UserId.HasValue) {
-                    if (!playerReadyStatus.ContainsKey(player.UserId.Value)) {
+            if (readyAvailable && !matchStarted)
+            {
+                if (player.UserId.HasValue)
+                {
+                    if (!playerReadyStatus.ContainsKey(player.UserId.Value))
+                    {
                         playerReadyStatus[player.UserId.Value] = false;
                     }
-                    if (!playerReadyStatus[player.UserId.Value]) {
+                    if (!playerReadyStatus[player.UserId.Value])
+                    {
                         PrintToPlayerChat(player, Localizer["matchzy.ready.markedunready"]);
-                    } else {
+                    }
+                    else
+                    {
                         playerReadyStatus[player.UserId.Value] = false;
                         PrintToPlayerChat(player, Localizer["matchzy.ready.markedunready"]);
                     }
@@ -90,12 +118,15 @@ namespace MatchZy
         }
 
         [ConsoleCommand("css_stay", "Stays after knife round")]
-        public void OnTeamStay(CCSPlayerController? player, CommandInfo? command) {
+        public void OnTeamStay(CCSPlayerController? player, CommandInfo? command)
+        {
             if (player == null) return;
-            
+
             Log($"[!stay command] {player.UserId}, TeamNum: {player.TeamNum}, knifeWinner: {knifeWinner}, isSideSelectionPhase: {isSideSelectionPhase}");
-            if (isSideSelectionPhase) {
-                if (player.TeamNum == knifeWinner) {
+            if (isSideSelectionPhase)
+            {
+                if (player.TeamNum == knifeWinner)
+                {
                     PrintToAllChat(Localizer["matchzy.knife.decidedtostay", knifeWinnerName]);
                     // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{knifeWinnerName}{ChatColors.Default} has decided to stay!");
                     StartLive();
@@ -105,12 +136,15 @@ namespace MatchZy
 
         [ConsoleCommand("css_switch", "Switch after knife round")]
         [ConsoleCommand("css_swap", "Switch after knife round")]
-        public void OnTeamSwitch(CCSPlayerController? player, CommandInfo? command) {
+        public void OnTeamSwitch(CCSPlayerController? player, CommandInfo? command)
+        {
             if (player == null) return;
-            
+
             Log($"[!switch command] {player.UserId}, TeamNum: {player.TeamNum}, knifeWinner: {knifeWinner}, isSideSelectionPhase: {isSideSelectionPhase}");
-            if (isSideSelectionPhase) {
-                if (player.TeamNum == knifeWinner) {
+            if (isSideSelectionPhase)
+            {
+                if (player.TeamNum == knifeWinner)
+                {
                     Server.ExecuteCommand("mp_swapteams;");
                     SwapSidesInTeamData(true);
                     PrintToAllChat(Localizer["matchzy.knife.decidedtoswitch", knifeWinnerName]);
@@ -121,80 +155,100 @@ namespace MatchZy
         }
 
         [ConsoleCommand("css_tech", "Pause the match")]
-        public void OnTechCommand(CCSPlayerController? player, CommandInfo? command) {       
+        public void OnTechCommand(CCSPlayerController? player, CommandInfo? command)
+        {
             PauseMatch(player, command);
         }
 
         [ConsoleCommand("css_pause", "Pause the match")]
-        public void OnPauseCommand(CCSPlayerController? player, CommandInfo? command) {     
+        public void OnPauseCommand(CCSPlayerController? player, CommandInfo? command)
+        {
             if (isPauseCommandForTactical)
             {
                 OnTacCommand(player, command);
-            }   
-            else 
+            }
+            else
             {
                 PauseMatch(player, command);
-            }    
+            }
         }
 
         [ConsoleCommand("css_fp", "Pause the match an admin")]
         [ConsoleCommand("css_forcepause", "Pause the match as an admin")]
         [ConsoleCommand("sm_pause", "Pause the match as an admin")]
-        public void OnForcePauseCommand(CCSPlayerController? player, CommandInfo? command) {            
+        public void OnForcePauseCommand(CCSPlayerController? player, CommandInfo? command)
+        {
             ForcePauseMatch(player, command);
         }
 
         [ConsoleCommand("css_fup", "Unpause the match an admin")]
         [ConsoleCommand("css_forceunpause", "Unpause the match as an admin")]
         [ConsoleCommand("sm_unpause", "Unpause the match as an admin")]
-        public void OnForceUnpauseCommand(CCSPlayerController? player, CommandInfo? command) {            
+        public void OnForceUnpauseCommand(CCSPlayerController? player, CommandInfo? command)
+        {
             ForceUnpauseMatch(player, command);
         }
 
         [ConsoleCommand("css_unpause", "Unpause the match")]
-        public void OnUnpauseCommand(CCSPlayerController? player, CommandInfo? command) {
-            if (isMatchLive && isPaused) {
+        public void OnUnpauseCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (isMatchLive && isPaused)
+            {
                 var pauseTeamName = unpauseData["pauseTeam"];
-                if ((string)pauseTeamName == "Admin" && player != null) {
+                if ((string)pauseTeamName == "Admin" && player != null)
+                {
                     PrintToPlayerChat(player, Localizer["matchzy.pause.onlyadmincanunpause"]);
                     return;
                 }
 
                 string unpauseTeamName = "Admin";
                 string remainingUnpauseTeam = "Admin";
-                if (player?.TeamNum == 2) {
+                if (player?.TeamNum == 2)
+                {
                     unpauseTeamName = reverseTeamSides["TERRORIST"].teamName;
                     remainingUnpauseTeam = reverseTeamSides["CT"].teamName;
-                    if (!(bool)unpauseData["t"]) {
+                    if (!(bool)unpauseData["t"])
+                    {
                         unpauseData["t"] = true;
                     }
-                    
-                } else if (player?.TeamNum == 3) {
+
+                }
+                else if (player?.TeamNum == 3)
+                {
                     unpauseTeamName = reverseTeamSides["CT"].teamName;
                     remainingUnpauseTeam = reverseTeamSides["TERRORIST"].teamName;
-                    if (!(bool)unpauseData["ct"]) {
+                    if (!(bool)unpauseData["ct"])
+                    {
                         unpauseData["ct"] = true;
                     }
-                } else {
+                }
+                else
+                {
                     return;
                 }
-                if ((bool)unpauseData["t"] && (bool)unpauseData["ct"]) {
+                if ((bool)unpauseData["t"] && (bool)unpauseData["ct"])
+                {
                     PrintToAllChat(Localizer["matchzy.pause.teamsunpausedthematch"]);
                     Server.ExecuteCommand("mp_unpause_match;");
                     isPaused = false;
                     unpauseData["ct"] = false;
                     unpauseData["t"] = false;
-                } else if (unpauseTeamName == "Admin") {
+                }
+                else if (unpauseTeamName == "Admin")
+                {
                     PrintToAllChat(Localizer["matchzy.pause.adminunpausedthematch"]);
                     Server.ExecuteCommand("mp_unpause_match;");
                     isPaused = false;
                     unpauseData["ct"] = false;
                     unpauseData["t"] = false;
-                } else {
+                }
+                else
+                {
                     PrintToAllChat(Localizer["matchzy.pause.teamwantstounpause", unpauseTeamName, remainingUnpauseTeam]);
                     // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{unpauseTeamName}{ChatColors.Default} wants to unpause the match. {ChatColors.Green}{remainingUnpauseTeam}{ChatColors.Default}, please write !unpause to confirm.");
                 }
-                if (!isPaused && pausedStateTimer != null) {
+                if (!isPaused && pausedStateTimer != null)
+                {
                     pausedStateTimer.Kill();
                     pausedStateTimer = null;
                 }
@@ -202,10 +256,12 @@ namespace MatchZy
         }
 
         [ConsoleCommand("css_tac", "Starts a tactical timeout for the requested team")]
-        public void OnTacCommand(CCSPlayerController? player, CommandInfo? command) {
+        public void OnTacCommand(CCSPlayerController? player, CommandInfo? command)
+        {
             if (player == null) return;
-            
-            if (matchStarted && isMatchLive) {
+
+            if (matchStarted && isMatchLive)
+            {
                 Log($"[.tac command sent via chat] Sent by: {player.UserId}, connectedPlayers: {connectedPlayers}");
                 if (isPaused)
                 {
@@ -214,92 +270,128 @@ namespace MatchZy
                     return;
                 }
                 var gameRules = Utilities.FindAllEntitiesByDesignerName<CCSGameRulesProxy>("cs_gamerules").First().GameRules!;
-                if (player.TeamNum == 2) {
-                    if (gameRules.TerroristTimeOuts > 0) {
+                if (player.TeamNum == 2)
+                {
+                    if (gameRules.TerroristTimeOuts > 0)
+                    {
                         Server.ExecuteCommand("timeout_terrorist_start");
-                    } else {
+                    }
+                    else
+                    {
                         // ReplyToUserCommand(player, "You do not have any tactical timeouts left!");
                         ReplyToUserCommand(player, Localizer["matchzy.cc.nomorepauses"]);
                     }
-                } else if (player.TeamNum == 3) {
-                    if (gameRules.CTTimeOuts > 0) {
+                }
+                else if (player.TeamNum == 3)
+                {
+                    if (gameRules.CTTimeOuts > 0)
+                    {
                         Server.ExecuteCommand("timeout_ct_start");
-                    } else {
+                    }
+                    else
+                    {
                         // ReplyToUserCommand(player, "You do not have any tactical timeouts left!");
                         ReplyToUserCommand(player, Localizer["matchzy.cc.nomorepauses"]);
                     }
-                } 
+                }
             }
         }
 
         [ConsoleCommand("css_skipveto", "Skips the current veto phase")]
         [ConsoleCommand("css_sv", "Skips the current veto phase")]
-        public void OnSkipVetoCommand(CCSPlayerController? player, CommandInfo? command) {            
-            if (IsPlayerAdmin(player, "css_skipveto", "@css/config")) {
-                if (matchStarted) {
-                    if (player == null) {
+        public void OnSkipVetoCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (IsPlayerAdmin(player, "css_skipveto", "@css/config"))
+            {
+                if (matchStarted)
+                {
+                    if (player == null)
+                    {
                         // ReplyToUserCommand(player, $"Skip veto command cannot be used if match has already started!");
                         ReplyToUserCommand(player, Localizer["matchzy.cc.skipvetomatchstarted"]);
-                    } else {
+                    }
+                    else
+                    {
                         // player.PrintToChat($"{chatPrefix} Skip veto command cannot be used if match has already started!");
                         PrintToPlayerChat(player, Localizer["matchzy.cc.skipvetomatchstarted"]);
                     }
                 }
-                else {
+                else
+                {
                     SkipVeto();
-                    if (player == null) {
+                    if (player == null)
+                    {
                         // ReplyToUserCommand(player, $"Veto phase has been cancelled!");
                         ReplyToUserCommand(player, Localizer["matchzy.cc.skipveto"]);
-                    } else {
+                    }
+                    else
+                    {
                         // player.PrintToChat($"{chatPrefix} Veto phase has been cancelled!");
                         PrintToPlayerChat(player, Localizer["matchzy.cc.skipveto"]);
                     }
                 }
-            } else {
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
 
         [ConsoleCommand("css_roundknife", "Toggles knife round for the match")]
         [ConsoleCommand("css_rk", "Toggles knife round for the match")]
-        public void OnKnifeCommand(CCSPlayerController? player, CommandInfo? command) {            
-            if (IsPlayerAdmin(player, "css_roundknife", "@css/config")) {
+        public void OnKnifeCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (IsPlayerAdmin(player, "css_roundknife", "@css/config"))
+            {
                 isKnifeRequired = !isKnifeRequired;
                 string knifeStatus = isKnifeRequired ? Localizer["matchzy.cc.enabled"] : Localizer["matchzy.cc.disabled"];
-                if (player == null) {
+                if (player == null)
+                {
                     // ReplyToUserCommand(player, $"Knife round is now {knifeStatus}!");
                     ReplyToUserCommand(player, Localizer["matchzy.cc.roundknife", knifeStatus]);
-                } else {
+                }
+                else
+                {
                     // player.PrintToChat($"{chatPrefix} Knife round is now {ChatColors.Green}{knifeStatus}{ChatColors.Default}!");
                     PrintToPlayerChat(player, Localizer["matchzy.cc.roundknife", knifeStatus]);
                 }
-            } else {
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
 
         [ConsoleCommand("css_readyrequired", "Sets number of ready players required to start the match")]
-        public void OnReadyRequiredCommand(CCSPlayerController? player, CommandInfo command) {
-            if (IsPlayerAdmin(player, "css_readyrequired", "@css/config")) {
-                if (command.ArgCount >= 2) {
+        public void OnReadyRequiredCommand(CCSPlayerController? player, CommandInfo command)
+        {
+            if (IsPlayerAdmin(player, "css_readyrequired", "@css/config"))
+            {
+                if (command.ArgCount >= 2)
+                {
                     string commandArg = command.ArgByIndex(1);
                     HandleReadyRequiredCommand(player, commandArg);
                 }
-                else {
+                else
+                {
                     string minimumReadyRequiredFormatted = (player == null) ? $"{minimumReadyRequired}" : $"{ChatColors.Green}{minimumReadyRequired}{ChatColors.Default}";
                     // ReplyToUserCommand(player, $"Current Ready Required: {minimumReadyRequiredFormatted}. Usage: !readyrequired <number_of_ready_players_required>");
                     ReplyToUserCommand(player, Localizer["matchzy.cc.minreadyrequired", minimumReadyRequiredFormatted]);
-                }                
-            } else {
+                }
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
 
         [ConsoleCommand("css_settings", "Shows the current match configuration/settings")]
-        public void OnMatchSettingsCommand(CCSPlayerController? player, CommandInfo? command) {
+        public void OnMatchSettingsCommand(CCSPlayerController? player, CommandInfo? command)
+        {
             if (player == null) return;
 
-            if (IsPlayerAdmin(player, "css_settings", "@css/config")) {
+            if (IsPlayerAdmin(player, "css_settings", "@css/config"))
+            {
                 string knifeStatus = isKnifeRequired ? Localizer["matchzy.cc.enabled"] : Localizer["matchzy.cc.disabled"];
                 string playoutStatus = isPlayOutEnabled ? Localizer["matchzy.cc.enabled"] : Localizer["matchzy.cc.disabled"];
                 // player.PrintToChat($"{chatPrefix} Current Settings:");
@@ -320,7 +412,9 @@ namespace MatchZy
                 }
                 // player.PrintToChat($"{chatPrefix} Playout: {ChatColors.Green}{playoutStatus}{ChatColors.Default}");
                 PrintToPlayerChat(player, Localizer["matchzy.cc.playoutstatus", playoutStatus]);
-            } else {
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
@@ -328,56 +422,78 @@ namespace MatchZy
         [ConsoleCommand("css_endmatch", "Ends and resets the current match")]
         [ConsoleCommand("get5_endmatch", "Ends and resets the current match")]
         [ConsoleCommand("css_forceend", "Ends and resets the current match")]
-        public void OnEndMatchCommand(CCSPlayerController? player, CommandInfo? command) {
-            if (IsPlayerAdmin(player, "css_endmatch", "@css/config")) {
-                if (!isPractice) {
+        public void OnEndMatchCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (IsPlayerAdmin(player, "css_endmatch", "@css/config"))
+            {
+                if (!isPractice)
+                {
                     // Server.PrintToChatAll($"{chatPrefix} An admin force-ended the match.");
                     PrintToAllChat(Localizer["matchzy.cc.endmatch"]);
                     ResetMatch();
-                } else {
+                }
+                else
+                {
                     // ReplyToUserCommand(player, "Practice mode is active, cannot end the match.");
                     ReplyToUserCommand(player, Localizer["matchzy.cc.endmatchispracc"]);
                 }
-            } else {
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
 
         [ConsoleCommand("css_restart", "Restarts the match")]
-        public void OnRestartMatchCommand(CCSPlayerController? player, CommandInfo? command) {
-            if (IsPlayerAdmin(player, "css_restart", "@css/config")) {
-                if (!isPractice) {
+        public void OnRestartMatchCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (IsPlayerAdmin(player, "css_restart", "@css/config"))
+            {
+                if (!isPractice)
+                {
                     ResetMatch();
-                } else {
+                }
+                else
+                {
                     // ReplyToUserCommand(player, "Practice mode is active, cannot restart the match.");
                     ReplyToUserCommand(player, Localizer["matchzy.cc.rrispracc"]);
                 }
-            } else {
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
 
         [ConsoleCommand("css_map", "Changes the map using changelevel")]
-        public void OnChangeMapCommand(CCSPlayerController? player, CommandInfo command) {
+        public void OnChangeMapCommand(CCSPlayerController? player, CommandInfo command)
+        {
             var mapName = command.ArgByIndex(1);
             HandleMapChangeCommand(player, mapName);
         }
 
         [ConsoleCommand("css_rmap", "Reloads the current map")]
-        private void OnMapReloadCommand(CCSPlayerController? player, CommandInfo? command) {
+        private void OnMapReloadCommand(CCSPlayerController? player, CommandInfo? command)
+        {
 
-            if (!IsPlayerAdmin(player)) {
+            if (!IsPlayerAdmin(player))
+            {
                 SendPlayerNotAdminMessage(player);
                 return;
             }
             string currentMapName = Server.MapName;
-            if (long.TryParse(currentMapName, out _)) { // Check if mapName is a long for workshop map ids
+            if (long.TryParse(currentMapName, out _))
+            { // Check if mapName is a long for workshop map ids
                 Server.ExecuteCommand($"bot_kick");
                 Server.ExecuteCommand($"host_workshop_map \"{currentMapName}\"");
-            } else if (Server.IsMapValid(currentMapName)) {
+            }
+            else if (Server.IsMapValid(currentMapName))
+            {
                 Server.ExecuteCommand($"bot_kick");
                 Server.ExecuteCommand($"changelevel \"{currentMapName}\"");
-            } else {
+            }
+            else
+            {
                 // ReplyToUserCommand(player, "Invalid map name!");
                 ReplyToUserCommand(player, Localizer["matchzy.cc.invalidmap"]);
             }
@@ -386,50 +502,66 @@ namespace MatchZy
         [ConsoleCommand("css_start", "Force starts the match")]
         [ConsoleCommand("css_force", "Force starts the match")]
         [ConsoleCommand("css_forcestart", "Force starts the match")]
-        public void OnStartCommand(CCSPlayerController? player, CommandInfo? command) {
-            if (IsPlayerAdmin(player, "css_start", "@css/config")) {
-                if (isPractice) {
+        public void OnStartCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (IsPlayerAdmin(player, "css_start", "@css/config"))
+            {
+                if (isPractice)
+                {
                     // ReplyToUserCommand(player, "Cannot start a match while in practice mode. Please use .exitprac command to exit practice mode first!");
                     ReplyToUserCommand(player, Localizer["matchzy.cc.startisprac"]);
                     return;
                 }
-                if (matchStarted) {
+                if (matchStarted)
+                {
                     //ReplyToUserCommand(player, "Start command cannot be used if match is already started! If you want to unpause, please use .unpause");
                     ReplyToUserCommand(player, Localizer["matchzy.cc.startmatchstarted"]);
-                } else {
+                }
+                else
+                {
                     //Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}Admin{ChatColors.Default} has started the game!");
                     PrintToAllChat(Localizer["matchzy.cc.gamestarted"]);
                     HandleMatchStart();
                 }
-            } else {
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
 
         [ConsoleCommand("css_asay", "Say as an admin")]
-        public void OnAdminSay(CCSPlayerController? player, CommandInfo? command) {
+        public void OnAdminSay(CCSPlayerController? player, CommandInfo? command)
+        {
             if (command == null) return;
-            if (player == null) {
+            if (player == null)
+            {
                 Server.PrintToChatAll($"{adminChatPrefix} {command.ArgString}");
                 return;
             }
-            if (!IsPlayerAdmin(player, "css_asay", "@css/chat")) {
+            if (!IsPlayerAdmin(player, "css_asay", "@css/chat"))
+            {
                 SendPlayerNotAdminMessage(player);
                 return;
             }
             string message = "";
-            for (int i = 1; i < command.ArgCount; i++) {
+            for (int i = 1; i < command.ArgCount; i++)
+            {
                 message += command.ArgByIndex(i) + " ";
             }
             Server.PrintToChatAll($"{adminChatPrefix} {message}");
         }
 
         [ConsoleCommand("reload_admins", "Reload admins of MatchZy")]
-        public void OnReloadAdmins(CCSPlayerController? player, CommandInfo? command) {
-            if (IsPlayerAdmin(player, "reload_admins", "@css/config")) {
+        public void OnReloadAdmins(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (IsPlayerAdmin(player, "reload_admins", "@css/config"))
+            {
                 LoadAdmins();
                 UpdatePlayersMap();
-            } else {
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
@@ -437,12 +569,14 @@ namespace MatchZy
         [ConsoleCommand("css_match", "Starts match mode")]
         public void OnMatchCommand(CCSPlayerController? player, CommandInfo? command)
         {
-            if (!IsPlayerAdmin(player, "css_match", "@css/map", "@custom/prac")) {
+            if (!IsPlayerAdmin(player, "css_match", "@css/map", "@custom/prac"))
+            {
                 SendPlayerNotAdminMessage(player);
                 return;
             }
 
-            if (matchStarted) {
+            if (matchStarted)
+            {
                 // ReplyToUserCommand(player, "MatchZy is already in match mode!");
                 ReplyToUserCommand(player, Localizer["matchzy.cc.match"]);
                 return;
@@ -454,12 +588,14 @@ namespace MatchZy
         [ConsoleCommand("css_exitprac", "Starts match mode")]
         public void OnExitPracCommand(CCSPlayerController? player, CommandInfo? command)
         {
-            if (!IsPlayerAdmin(player, "css_exitprac", "@css/map", "@custom/prac")) {
+            if (!IsPlayerAdmin(player, "css_exitprac", "@css/map", "@custom/prac"))
+            {
                 SendPlayerNotAdminMessage(player);
                 return;
             }
 
-            if (matchStarted) {
+            if (matchStarted)
+            {
                 //ReplyToUserCommand(player, "MatchZy is already in match mode!");
                 ReplyToUserCommand(player, Localizer["matchzy.cc.exitprac"]);
                 return;
@@ -471,7 +607,8 @@ namespace MatchZy
         [ConsoleCommand("css_rcon", "Triggers provided command on the server")]
         public void OnRconCommand(CCSPlayerController? player, CommandInfo command)
         {
-            if (!IsPlayerAdmin(player, "css_rcon", "@css/rcon")) {
+            if (!IsPlayerAdmin(player, "css_rcon", "@css/rcon"))
+            {
                 SendPlayerNotAdminMessage(player);
                 return;
             }
@@ -488,27 +625,35 @@ namespace MatchZy
         }
 
         [ConsoleCommand("css_playout", "Toggles playout (Playing of max rounds)")]
-        public void OnPlayoutCommand(CCSPlayerController? player, CommandInfo? command) {            
-            if (IsPlayerAdmin(player, "css_playout", "@css/config")) {
+        public void OnPlayoutCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (IsPlayerAdmin(player, "css_playout", "@css/config"))
+            {
                 isPlayOutEnabled = !isPlayOutEnabled;
-                string playoutStatus = isPlayOutEnabled? Localizer["matchzy.cc.enabled"] : Localizer["matchzy.cc.disabled"];
-                if (player == null) {
+                string playoutStatus = isPlayOutEnabled ? Localizer["matchzy.cc.enabled"] : Localizer["matchzy.cc.disabled"];
+                if (player == null)
+                {
                     // ReplyToUserCommand(player, $"Playout is now {playoutStatus}!");
                     ReplyToUserCommand(player, Localizer["matchzy.cc.playout", playoutStatus]);
-                } else {
+                }
+                else
+                {
                     // player.PrintToChat($"{chatPrefix} Playout is now {ChatColors.Green}{playoutStatus}{ChatColors.Default}!");
                     PrintToPlayerChat(player, Localizer["matchzy.cc.playout", playoutStatus]);
                 }
 
                 HandlePlayoutConfig();
-                
-            } else {
+
+            }
+            else
+            {
                 SendPlayerNotAdminMessage(player);
             }
         }
 
         [ConsoleCommand("version", "Returns server version")]
-        public void OnVersionCommand(CCSPlayerController? player, CommandInfo? command) {      
+        public void OnVersionCommand(CCSPlayerController? player, CommandInfo? command)
+        {
             if (command == null) return;
             string steamInfFilePath = Path.Combine(Server.GameDirectory, "csgo", "steam.inf");
 

--- a/DemoManagement.cs
+++ b/DemoManagement.cs
@@ -63,9 +63,10 @@ namespace MatchZy
             int roundNumber = t1score + t2score;
             AddTimer(delay, () =>
             {
-                if (isDemoRecording) 
+                if (isDemoRecording)
                 {
                     Server.ExecuteCommand($"tv_stoprecord");
+                    isDemoRecording = false;
                 }
                 isDemoRecording = false;
                 AddTimer(15, () =>

--- a/Utility.cs
+++ b/Utility.cs
@@ -268,9 +268,8 @@ namespace MatchZy
             sideSelectionMessageTimer ??= AddTimer(chatTimerDelay, SendSideSelectionMessage, TimerFlags.REPEAT);
         }
 
-        private void StartLive()
+        private void SetLiveFlags()
         {
-
             // Setting match phases bools
             isWarmup = false;
             isSideSelectionPhase = false;

--- a/Utility.cs
+++ b/Utility.cs
@@ -1002,6 +1002,7 @@ namespace MatchZy
 
         public void HandlePostRoundStartEvent(EventRoundStart @event)
         {
+            if (!matchStarted) return;
             HandleCoaches();
             CreateMatchZyRoundDataBackup();
             InitPlayerDamageInfo();

--- a/Utility.cs
+++ b/Utility.cs
@@ -32,42 +32,52 @@ namespace MatchZy
             player.PrintToChat($"{chatPrefix} {message}");
         }
 
-        private void LoadAdmins() {
+        private void LoadAdmins()
+        {
             string fileName = "MatchZy/admins.json";
             string filePath = Path.Join(Server.GameDirectory + "/csgo/cfg", fileName);
 
-            if (File.Exists(filePath)) {
-                try {
-                    using (StreamReader fileReader = File.OpenText(filePath)) {
+            if (File.Exists(filePath))
+            {
+                try
+                {
+                    using (StreamReader fileReader = File.OpenText(filePath))
+                    {
                         string jsonContent = fileReader.ReadToEnd();
-                        if (!string.IsNullOrEmpty(jsonContent)) {
+                        if (!string.IsNullOrEmpty(jsonContent))
+                        {
                             JsonSerializerOptions options = new()
                             {
                                 AllowTrailingCommas = true,
                             };
                             loadedAdmins = JsonSerializer.Deserialize<Dictionary<string, string>>(jsonContent, options) ?? new Dictionary<string, string>();
                         }
-                        else {
+                        else
+                        {
                             // Handle the case where the JSON content is empty or null
                             loadedAdmins = new Dictionary<string, string>();
                         }
                     }
-                    foreach (var kvp in loadedAdmins) {
+                    foreach (var kvp in loadedAdmins)
+                    {
                         Log($"[ADMIN] Username: {kvp.Key}, Role: {kvp.Value}");
                     }
                 }
-                catch (Exception e) {
+                catch (Exception e)
+                {
                     Log($"[LoadAdmins FATAL] An error occurred: {e.Message}");
                 }
             }
-            else {
+            else
+            {
                 Log("[LoadAdmins] The JSON file does not exist. Creating one with default content");
                 Dictionary<string, string> defaultAdmins = new()
                 {
                     { "steamid", "" }
                 };
 
-                try {
+                try
+                {
                     JsonSerializerOptions options = new()
                     {
                         WriteIndented = true,
@@ -85,13 +95,15 @@ namespace MatchZy
 
                     Log("[LoadAdmins] Created a new JSON file with default content.");
                 }
-                catch (Exception e) {
+                catch (Exception e)
+                {
                     Log($"[LoadAdmins FATAL] Error creating the JSON file: {e.Message}");
                 }
             }
         }
 
-        private bool IsPlayerAdmin(CCSPlayerController? player, string command = "", params string[] permissions) {
+        private bool IsPlayerAdmin(CCSPlayerController? player, string command = "", params string[] permissions)
+        {
             if (everyoneIsAdmin.Value) return true; // Everyone is treated as admin if matchzy_everyone_is_admin is true.
             string[] updatedPermissions = permissions.Concat(new[] { "@css/root" }).ToArray();
             RequiresPermissionsOr attr = new(updatedPermissions)
@@ -103,21 +115,26 @@ namespace MatchZy
             if (loadedAdmins.ContainsKey(player.SteamID.ToString())) return true; // Admin exists in admins.json of MatchZy
             return false;
         }
-        
-        private int GetRealPlayersCount() {
+
+        private int GetRealPlayersCount()
+        {
             return playerData.Count;
         }
 
-        private void SendUnreadyPlayersMessage() {
+        private void SendUnreadyPlayersMessage()
+        {
             if (!isWarmup || matchStarted) return;
             List<string> unreadyPlayers = new();
 
-            foreach (var key in playerReadyStatus.Keys) {
-                if (playerReadyStatus[key] == false) {
+            foreach (var key in playerReadyStatus.Keys)
+            {
+                if (playerReadyStatus[key] == false)
+                {
                     unreadyPlayers.Add(playerData[key].PlayerName);
                 }
             }
-            if (unreadyPlayers.Count > 0) {
+            if (unreadyPlayers.Count > 0)
+            {
                 string unreadyPlayerList = string.Join(", ", unreadyPlayers);
                 string minimumReadyRequiredMessage = isMatchSetup ? "" : $"[Minimum ready players required: {ChatColors.Green}{minimumReadyRequired}{ChatColors.Default}]";
 
@@ -130,7 +147,9 @@ namespace MatchZy
                 {
                     PrintToAllChat(Localizer["matchzy.utility.unreadyplayers", unreadyPlayerList, minimumReadyRequiredMessage]);
                 }
-            } else {
+            }
+            else
+            {
                 int countOfReadyPlayers = playerReadyStatus.Count(kv => kv.Value == true);
                 if (isMatchSetup)
                 {
@@ -145,36 +164,52 @@ namespace MatchZy
             }
         }
 
-        private void SendPausedStateMessage() {
-            if (isPaused && matchStarted) {
+        private void SendPausedStateMessage()
+        {
+            if (isPaused && matchStarted)
+            {
                 var pauseTeamName = unpauseData["pauseTeam"];
-                if ((string)pauseTeamName == "Admin") {
+                if ((string)pauseTeamName == "Admin")
+                {
                     PrintToAllChat(Localizer["matchzy.pause.adminpausedthematch"]);
-                } else if ((string)pauseTeamName == "RoundRestore" && !(bool)unpauseData["t"] && !(bool)unpauseData["ct"]) {
+                }
+                else if ((string)pauseTeamName == "RoundRestore" && !(bool)unpauseData["t"] && !(bool)unpauseData["ct"])
+                {
                     PrintToAllChat(Localizer["matchzy.pause.pausedbecauserestore"]);
-                } else if ((bool)unpauseData["t"] && !(bool)unpauseData["ct"]) {
+                }
+                else if ((bool)unpauseData["t"] && !(bool)unpauseData["ct"])
+                {
                     PrintToAllChat(Localizer["matchzy.pause.teamwantstounpause", reverseTeamSides["TERRORIST"].teamName, reverseTeamSides["CT"].teamName]);
-                } else if (!(bool)unpauseData["t"] && (bool)unpauseData["ct"]) {
+                }
+                else if (!(bool)unpauseData["t"] && (bool)unpauseData["ct"])
+                {
                     PrintToAllChat(Localizer["matchzy.pause.teamwantstounpause", reverseTeamSides["CT"].teamName, reverseTeamSides["TERRORIST"].teamName]);
-                } else if (!(bool)unpauseData["t"] && !(bool)unpauseData["ct"]) {
+                }
+                else if (!(bool)unpauseData["t"] && !(bool)unpauseData["ct"])
+                {
                     PrintToAllChat(Localizer["matchzy.pause.pausedthematch", pauseTeamName]);
                 }
             }
         }
 
-        private void ExecWarmupCfg() {
+        private void ExecWarmupCfg()
+        {
             var absolutePath = Path.Join(Server.GameDirectory + "/csgo/cfg", warmupCfgPath);
 
-            if (File.Exists(Path.Join(Server.GameDirectory + "/csgo/cfg", warmupCfgPath))) {
+            if (File.Exists(Path.Join(Server.GameDirectory + "/csgo/cfg", warmupCfgPath)))
+            {
                 Log($"[StartWarmup] Starting warmup! Executing Warmup CFG from {warmupCfgPath}");
                 Server.ExecuteCommand($"exec {warmupCfgPath}");
-            } else {
+            }
+            else
+            {
                 Log($"[StartWarmup] Starting warmup! Warmup CFG not found in {absolutePath}, using default CFG!");
                 Server.ExecuteCommand("bot_kick;bot_quota 0;mp_autokick 0;mp_autoteambalance 0;mp_buy_anywhere 0;mp_buytime 15;mp_death_drop_gun 0;mp_free_armor 0;mp_ignore_round_win_conditions 0;mp_limitteams 0;mp_radar_showall 0;mp_respawn_on_death_ct 0;mp_respawn_on_death_t 0;mp_solid_teammates 0;mp_spectators_max 20;mp_maxmoney 16000;mp_startmoney 16000;mp_timelimit 0;sv_alltalk 0;sv_auto_full_alltalk_during_warmup_half_end 0;sv_deadtalk 1;sv_full_alltalk 0;sv_grenade_trajectory 0;sv_hibernate_when_empty 0;mp_weapons_allow_typecount -1;sv_infinite_ammo 0;sv_showimpacts 0;sv_voiceenable 1;sm_cvar sv_mute_players_with_social_penalties 0;sv_mute_players_with_social_penalties 0;tv_relayvoice 1;sv_cheats 0;mp_ct_default_melee weapon_knife;mp_ct_default_secondary weapon_hkp2000;mp_ct_default_primary \"\";mp_t_default_melee weapon_knife;mp_t_default_secondary weapon_glock;mp_t_default_primary;mp_maxrounds 24;mp_warmup_start;mp_warmup_pausetimer 1;mp_warmuptime 9999;cash_team_bonus_shorthanded 0;");
             }
         }
 
-        private void StartWarmup() {
+        private void StartWarmup()
+        {
             unreadyPlayerMessageTimer?.Kill();
             unreadyPlayerMessageTimer = null;
             unreadyPlayerMessageTimer ??= AddTimer(chatTimerDelay, SendUnreadyPlayersMessage, TimerFlags.REPEAT);
@@ -182,26 +217,30 @@ namespace MatchZy
             ExecWarmupCfg();
         }
 
-        private void StartKnifeRound() {
+        private void StartKnifeRound()
+        {
             // Kills unready players message timer
-            if (unreadyPlayerMessageTimer != null) {
+            if (unreadyPlayerMessageTimer != null)
+            {
                 unreadyPlayerMessageTimer.Kill();
                 unreadyPlayerMessageTimer = null;
             }
-            
+
             // Setting match phases bools
             isKnifeRound = true;
-            matchStarted = true;
             readyAvailable = false;
             isWarmup = false;
 
             var absolutePath = Path.Join(Server.GameDirectory + "/csgo/cfg", knifeCfgPath);
 
-            if (File.Exists(Path.Join(Server.GameDirectory + "/csgo/cfg", knifeCfgPath))) {
+            if (File.Exists(Path.Join(Server.GameDirectory + "/csgo/cfg", knifeCfgPath)))
+            {
                 Log($"[StartKnifeRound] Starting Knife! Executing Knife CFG from {knifeCfgPath}");
                 Server.ExecuteCommand($"exec {knifeCfgPath}");
                 Server.ExecuteCommand("mp_restartgame 1;mp_warmup_end;");
-            } else {
+            }
+            else
+            {
                 Log($"[StartKnifeRound] Starting Knife! Knife CFG not found in {absolutePath}, using default CFG!");
                 Server.ExecuteCommand("mp_ct_default_secondary \"\";mp_free_armor 1;mp_freezetime 10;mp_give_player_c4 0;mp_maxmoney 0;mp_respawn_immunitytime 0;mp_respawn_on_death_ct 0;mp_respawn_on_death_t 0;mp_roundtime 1.92;mp_roundtime_defuse 1.92;mp_roundtime_hostage 1.92;mp_t_default_secondary \"\";mp_round_restart_delay 3;mp_team_intro_time 0;mp_restartgame 1;mp_warmup_end;");
             }
@@ -211,13 +250,15 @@ namespace MatchZy
             PrintToAllChat($"{ChatColors.Green}KNIFE!");
         }
 
-        private void SendSideSelectionMessage() {
+        private void SendSideSelectionMessage()
+        {
             if (!isSideSelectionPhase) return;
             PrintToAllChat(Localizer["matchzy.knife.sidedecisionpending", knifeWinnerName]);
             // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{knifeWinnerName}{ChatColors.Default} Won the knife. Waiting for them to type {ChatColors.Green}.stay{ChatColors.Default} or {ChatColors.Green}.switch{ChatColors.Default}");
         }
 
-        private void StartAfterKnifeWarmup() {
+        private void StartAfterKnifeWarmup()
+        {
             isWarmup = true;
             ExecWarmupCfg();
             knifeWinnerName = knifeWinner == 3 ? reverseTeamSides["CT"].teamName : reverseTeamSides["TERRORIST"].teamName;
@@ -226,9 +267,11 @@ namespace MatchZy
             // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{knifeWinnerName}{ChatColors.Default} Won the knife. Waiting for them to type {ChatColors.Green}.stay{ChatColors.Default} or {ChatColors.Green}.switch{ChatColors.Default}");
             sideSelectionMessageTimer ??= AddTimer(chatTimerDelay, SendSideSelectionMessage, TimerFlags.REPEAT);
         }
-        
-        private void SetLiveFlags()
+
+        private void StartLive()
         {
+
+            // Setting match phases bools
             isWarmup = false;
             isSideSelectionPhase = false;
             matchStarted = true;
@@ -243,19 +286,22 @@ namespace MatchZy
             KillPhaseTimers();
             ExecLiveCFG();
             // Adding timer here to make sure that CFG execution is completed till then
-            AddTimer(1, () => {
+            AddTimer(1, () =>
+            {
                 HandlePlayoutConfig();
                 ExecuteChangedConvars();
-            }); 
+            });
         }
 
-        private void StartLive() {
+        private void StartLive()
+        {
             SetupLiveFlagsAndCfg();
+            StartDemoRecording();
 
             // Storing 0-0 score backup file as lastBackupFileName, so that .stop functions properly in first round.
             lastBackupFileName = $"matchzy_{liveMatchId}_{matchConfig.CurrentMapNumber}_round00.txt";
             lastMatchZyBackupFileName = $"matchzy_data_backup_{liveMatchId}_{matchConfig.CurrentMapNumber}_round_00.json";
-            
+
             // This is to reload the map once it is over so that all flags are reset accordingly
             Server.ExecuteCommand("mp_match_end_restart true");
 
@@ -269,12 +315,14 @@ namespace MatchZy
                 MapNumber = matchConfig.CurrentMapNumber,
             };
 
-            Task.Run(async () => {
+            Task.Run(async () =>
+            {
                 await SendEventAsync(goingLiveEvent);
             });
         }
 
-        private void KillPhaseTimers() {
+        private void KillPhaseTimers()
+        {
             unreadyPlayerMessageTimer?.Kill();
             sideSelectionMessageTimer?.Kill();
             pausedStateTimer?.Kill();
@@ -284,15 +332,18 @@ namespace MatchZy
         }
 
 
-        private (int alivePlayers, int totalHealth) GetAlivePlayers(int team) {
+        private (int alivePlayers, int totalHealth) GetAlivePlayers(int team)
+        {
             int count = 0;
             int totalHealth = 0;
-            foreach (var key in playerData.Keys) {
+            foreach (var key in playerData.Keys)
+            {
                 CCSPlayerController player = playerData[key];
                 if (team == 2 && reverseTeamSides["TERRORIST"].coach == player) continue;
                 if (team == 3 && reverseTeamSides["CT"].coach == player) continue;
                 if (!IsPlayerValid(player)) continue;
-                if (player.TeamNum == team) {
+                if (player.TeamNum == team)
+                {
                     if (player.PlayerPawn.Value!.Health > 0) count++;
                     totalHealth += player.PlayerPawn.Value!.Health;
                 }
@@ -300,12 +351,13 @@ namespace MatchZy
             return (count, totalHealth);
         }
 
-        private void ResetMatch(bool warmupCfgRequired = true) 
+        private void ResetMatch(bool warmupCfgRequired = true)
         {
             try
             {
                 // We stop demo recording if a live match was restarted
-                if (matchStarted && isDemoRecording) {
+                if (matchStarted && isDemoRecording)
+                {
                     Server.ExecuteCommand($"tv_stoprecord");
                     isDemoRecording = false;
                 }
@@ -318,8 +370,8 @@ namespace MatchZy
                 isWarmup = true;
                 isKnifeRound = false;
                 isSideSelectionPhase = false;
-                isMatchLive = false;    
-                liveMatchId = -1; 
+                isMatchLive = false;
+                liveMatchId = -1;
                 isPractice = false;
                 isDryRun = false;
                 isVeto = false;
@@ -331,11 +383,12 @@ namespace MatchZy
                 isRoundRestorePending = false;
 
                 // Unready all players
-                foreach (var key in playerReadyStatus.Keys) {
+                foreach (var key in playerReadyStatus.Keys)
+                {
                     playerReadyStatus[key] = false;
                 }
 
-                teamReadyOverride = new() 
+                teamReadyOverride = new()
                 {
                     {CsTeam.Terrorist, false},
                     {CsTeam.CounterTerrorist, false},
@@ -362,7 +415,7 @@ namespace MatchZy
                 lastGrenadesData = new();
                 nadeSpecificLastGrenadeData = new();
                 UnpauseMatch();
-                
+
                 matchzyTeam1.teamName = "COUNTER-TERRORISTS";
                 matchzyTeam2.teamName = "TERRORISTS";
 
@@ -396,9 +449,12 @@ namespace MatchZy
 
                 KillPhaseTimers();
                 UpdatePlayersMap();
-                if (warmupCfgRequired) {
+                if (warmupCfgRequired)
+                {
                     StartWarmup();
-                } else {
+                }
+                else
+                {
                     // Since we should be already in warmup phase by this point, we are juts setting up the SendUnreadyPlayersMessage timer
                     unreadyPlayerMessageTimer?.Kill();
                     unreadyPlayerMessageTimer = null;
@@ -408,7 +464,7 @@ namespace MatchZy
             catch (Exception ex)
             {
                 Log($"[ResetMatch - FATAL] [ERROR]: {ex.Message}");
-            } 
+            }
         }
 
         public void SkipVeto()
@@ -420,7 +476,8 @@ namespace MatchZy
             StartWarmup();
         }
 
-        private void UpdatePlayersMap() {
+        private void UpdatePlayersMap()
+        {
             try
             {
                 var playerEntities = Utilities.FindAllEntitiesByDesignerName<CCSPlayerController>("cs_player_controller");
@@ -429,13 +486,16 @@ namespace MatchZy
 
                 // Clear the playerData dictionary by creating a new instance to add fresh data.
                 playerData = new Dictionary<int, CCSPlayerController>();
-                foreach (var player in playerEntities) {
+                foreach (var player in playerEntities)
+                {
                     if (player == null) continue;
                     if (!player.IsValid || player.IsBot || player.IsHLTV) continue;
 
-                    if (isMatchSetup || matchModeOnly) {
+                    if (isMatchSetup || matchModeOnly)
+                    {
                         CsTeam team = GetPlayerTeam(player);
-                        if (team == CsTeam.None && player.UserId.HasValue) {
+                        if (team == CsTeam.None && player.UserId.HasValue)
+                        {
                             Server.ExecuteCommand($"kickid {(ushort)player.UserId}");
                             continue;
                         }
@@ -445,13 +505,15 @@ namespace MatchZy
                     // Hence checking whether the player is actually in the server or not
                     if (player.Connected != PlayerConnectedState.PlayerConnected) continue;
 
-                    if (player.UserId.HasValue) {
+                    if (player.UserId.HasValue)
+                    {
 
                         // Updating playerData and playerReadyStatus
                         playerData[player.UserId.Value] = player;
 
                         // Adding missing player in playerReadyStatus
-                        if (!playerReadyStatus.ContainsKey(player.UserId.Value)) {
+                        if (!playerReadyStatus.ContainsKey(player.UserId.Value))
+                        {
                             playerReadyStatus[player.UserId.Value] = false;
                         }
                     }
@@ -459,8 +521,10 @@ namespace MatchZy
                 }
 
                 // Removing disconnected players from playerReadyStatus
-                foreach (var key in playerReadyStatus.Keys.ToList()) {
-                    if (!playerData.ContainsKey(key)) {
+                foreach (var key in playerReadyStatus.Keys.ToList())
+                {
+                    if (!playerData.ContainsKey(key))
+                    {
                         // Key is not present in playerData, so remove it from playerReadyStatus
                         playerReadyStatus.Remove(key);
                     }
@@ -479,22 +543,31 @@ namespace MatchZy
             (int tAlive, int tHealth) = GetAlivePlayers(2);
             (int ctAlive, int ctHealth) = GetAlivePlayers(3);
             Log($"[KNIFE OVER] CT Alive: {ctAlive} with Total Health: {ctHealth}, T Alive: {tAlive} with Total Health: {tHealth}");
-            if (ctAlive > tAlive) {
+            if (ctAlive > tAlive)
+            {
                 knifeWinner = 3;
-            } else if (tAlive > ctAlive) {
+            }
+            else if (tAlive > ctAlive)
+            {
                 knifeWinner = 2;
-            } else if (ctHealth > tHealth) {
+            }
+            else if (ctHealth > tHealth)
+            {
                 knifeWinner = 3;
-            } else if (tHealth > ctHealth) {
+            }
+            else if (tHealth > ctHealth)
+            {
                 knifeWinner = 2;
-            } else {
+            }
+            else
+            {
                 // Choosing a winner randomly
                 Random random = new();
                 knifeWinner = random.Next(2, 4);
             }
         }
 
-        private void HandleKnifeWinner(EventCsWinPanelRound @event) 
+        private void HandleKnifeWinner(EventCsWinPanelRound @event)
         {
             DetermineKnifeWinner();
             // Below code is working partially (Winner audio plays correctly for knife winner team, but may display round winner incorrectly)
@@ -509,92 +582,124 @@ namespace MatchZy
             // @event.FunfactData2 = empty;
             // @event.FunfactData3 = empty;
             int finalEvent = 10;
-            if (knifeWinner == 3) {
+            if (knifeWinner == 3)
+            {
                 finalEvent = 8;
-            } else if (knifeWinner == 2) {
+            }
+            else if (knifeWinner == 2)
+            {
                 finalEvent = 9;
             }
             Log($"[KNIFE WINNER] Won by: {knifeWinner}, finalEvent: {@event.FinalEvent}, newFinalEvent: {finalEvent}");
             @event.FinalEvent = finalEvent;
         }
 
-        private void HandleMapChangeCommand(CCSPlayerController? player, string mapName) {
-            if (!IsPlayerAdmin(player, "css_map", "@css/map")) {
+        private void HandleMapChangeCommand(CCSPlayerController? player, string mapName)
+        {
+            if (!IsPlayerAdmin(player, "css_map", "@css/map"))
+            {
                 SendPlayerNotAdminMessage(player);
                 return;
             }
 
-            if (matchStarted) {
+            if (matchStarted)
+            {
                 // ReplyToUserCommand(player, $"Map cannot be changed once the match is started!");
-                ReplyToUserCommand(player, Localizer["matchzy.utility.matchstarted"]);             
+                ReplyToUserCommand(player, Localizer["matchzy.utility.matchstarted"]);
                 return;
             }
 
-            if (!mapName.Contains("_")) {
+            if (!mapName.Contains("_"))
+            {
                 mapName = "de_" + mapName;
             }
 
-            if (long.TryParse(mapName, out _)) { // Check if mapName is a long for workshop map ids
+            if (!mapName.Contains("_"))
+            {
+                mapName = "de_" + mapName;
+            }
+
+            if (long.TryParse(mapName, out _))
+            { // Check if mapName is a long for workshop map ids
                 Server.ExecuteCommand($"bot_kick");
                 Server.ExecuteCommand($"host_workshop_map \"{mapName}\"");
-            } else if (Server.IsMapValid(mapName)) {
+            }
+            else if (Server.IsMapValid(mapName))
+            {
                 Server.ExecuteCommand($"bot_kick");
                 Server.ExecuteCommand($"changelevel \"{mapName}\"");
-            } else {
+            }
+            else
+            {
                 ReplyToUserCommand(player, $"Invalid map name!");
             }
         }
 
-        private void HandleReadyRequiredCommand(CCSPlayerController? player, string commandArg) {
-            if (!IsPlayerAdmin(player, "css_readyrequired", "@css/config")) {
+        private void HandleReadyRequiredCommand(CCSPlayerController? player, string commandArg)
+        {
+            if (!IsPlayerAdmin(player, "css_readyrequired", "@css/config"))
+            {
                 SendPlayerNotAdminMessage(player);
                 return;
             }
-            
-            if (!string.IsNullOrWhiteSpace(commandArg)) {
-                if (int.TryParse(commandArg, out int readyRequired) && readyRequired >= 0 && readyRequired <= 32) {
+
+            if (!string.IsNullOrWhiteSpace(commandArg))
+            {
+                if (int.TryParse(commandArg, out int readyRequired) && readyRequired >= 0 && readyRequired <= 32)
+                {
                     minimumReadyRequired = readyRequired;
                     string minimumReadyRequiredFormatted = (player == null) ? $"{minimumReadyRequired}" : $"{ChatColors.Green}{minimumReadyRequired}{ChatColors.Default}";
                     // ReplyToUserCommand(player, $"Minimum ready players required to start the match are now set to: {minimumReadyRequiredFormatted}");
                     ReplyToUserCommand(player, Localizer["matchzy.utility.minreadyplayers", minimumReadyRequiredFormatted]);
                     CheckLiveRequired();
                 }
-                else {
+                else
+                {
                     // ReplyToUserCommand(player, $"Invalid value for readyrequired. Please specify a valid non-negative number. Usage: !readyrequired <number_of_ready_players_required>");
                     ReplyToUserCommand(player, Localizer["matchzy.utility.rrinvalidvalue"]);
                 }
             }
-            else {
+            else
+            {
                 string minimumReadyRequiredFormatted = (player == null) ? $"{minimumReadyRequired}" : $"{ChatColors.Green}{minimumReadyRequired}{ChatColors.Default}";
                 // ReplyToUserCommand(player, $"Current Ready Required: {minimumReadyRequiredFormatted} .Usage: !readyrequired <number_of_ready_players_required>");
                 ReplyToUserCommand(player, Localizer["matchzy.utility.currentreadyrequired", minimumReadyRequiredFormatted]);
             }
         }
 
-        private void CheckLiveRequired() {
+        private void CheckLiveRequired()
+        {
             if (!readyAvailable || matchStarted) return;
 
             // Todo: Implement a same ready system for both pug and match
             int countOfReadyPlayers = playerReadyStatus.Count(kv => kv.Value == true);
             bool liveRequired = false;
-            if (isMatchSetup) {
-                if (IsTeamsReady() && IsSpectatorsReady()) {
+            if (isMatchSetup)
+            {
+                if (IsTeamsReady() && IsSpectatorsReady())
+                {
                     liveRequired = true;
                 }
             }
-            else if (minimumReadyRequired == 0) {
-                if (countOfReadyPlayers >= connectedPlayers && connectedPlayers > 0) {
+            else if (minimumReadyRequired == 0)
+            {
+                if (countOfReadyPlayers >= connectedPlayers && connectedPlayers > 0)
+                {
                     liveRequired = true;
                 }
-            } else if (countOfReadyPlayers >= minimumReadyRequired) {
+            }
+            else if (countOfReadyPlayers >= minimumReadyRequired)
+            {
                 liveRequired = true;
             }
-            if (liveRequired) {
+            if (liveRequired)
+            {
                 HandleMatchStart();
             }
         }
 
-        private void HandleMatchStart() {
+        private void HandleMatchStart()
+        {
             isPractice = false;
             isDryRun = false;
             if (isRoundRestorePending)
@@ -605,12 +710,15 @@ namespace MatchZy
                 return;
             }
             // If default names, we pick a player and use their name as their team name
-            if (matchzyTeam1.teamName == "COUNTER-TERRORISTS") {
+            if (matchzyTeam1.teamName == "COUNTER-TERRORISTS")
+            {
                 // matchzyTeam1.teamName = teamName;
                 teamSides[matchzyTeam1] = "CT";
                 reverseTeamSides["CT"] = matchzyTeam1;
-                foreach (var key in playerData.Keys) {
-                    if (playerData[key].TeamNum == 3) {
+                foreach (var key in playerData.Keys)
+                {
+                    if (playerData[key].TeamNum == 3)
+                    {
                         matchzyTeam1.teamName = "team_" + RemoveSpecialCharacters(playerData[key].PlayerName.Replace(" ", "_"));
                         if (matchzyTeam1.coach != null) matchzyTeam1.coach.Clan = $"[{matchzyTeam1.teamName} COACH]";
                         break;
@@ -619,12 +727,15 @@ namespace MatchZy
                 // Server.ExecuteCommand($"mp_teamname_1 {matchzyTeam1.teamName}");
             }
 
-            if (matchzyTeam2.teamName == "TERRORISTS") {
+            if (matchzyTeam2.teamName == "TERRORISTS")
+            {
                 // matchzyTeam2.teamName = teamName;
                 teamSides[matchzyTeam2] = "TERRORIST";
                 reverseTeamSides["TERRORIST"] = matchzyTeam2;
-                foreach (var key in playerData.Keys) {
-                    if (playerData[key].TeamNum == 2) {
+                foreach (var key in playerData.Keys)
+                {
+                    if (playerData[key].TeamNum == 2)
+                    {
                         matchzyTeam2.teamName = "team_" + RemoveSpecialCharacters(playerData[key].PlayerName.Replace(" ", "_"));
                         if (matchzyTeam2.coach != null) matchzyTeam2.coach.Clan = $"[{matchzyTeam2.teamName} COACH]";
                         break;
@@ -639,7 +750,7 @@ namespace MatchZy
             HandleClanTags();
 
             string seriesType = "BO" + matchConfig.NumMaps.ToString();
-            liveMatchId = database.InitMatch(matchzyTeam1.teamName, matchzyTeam2.teamName, "-" , isMatchSetup, liveMatchId, matchConfig.CurrentMapNumber, seriesType);
+            liveMatchId = database.InitMatch(matchzyTeam1.teamName, matchzyTeam2.teamName, "-", isMatchSetup, liveMatchId, matchConfig.CurrentMapNumber, seriesType);
             SetupRoundBackupFile();
 
             GetSpawns();
@@ -648,12 +759,11 @@ namespace MatchZy
             {
                 CreateVeto();
             }
-            else if (isKnifeRequired) 
+            else if (isKnifeRequired)
             {
-                StartDemoRecording();
                 StartKnifeRound();
-            } 
-            else 
+            }
+            else
             {
                 StartDemoRecording();
                 StartLive();
@@ -664,25 +774,37 @@ namespace MatchZy
             }
         }
 
-        public void HandleClanTags() {
+        public void HandleClanTags()
+        {
             // Currently it is not possible to keep updating player tags while in warmup without restarting the match
             // Hence returning from here until we find a proper solution
             return;
-            
-            if (readyAvailable && !matchStarted) {
-                foreach (var key in playerData.Keys) {
-                    if (playerReadyStatus[key]) {
+
+            if (readyAvailable && !matchStarted)
+            {
+                foreach (var key in playerData.Keys)
+                {
+                    if (playerReadyStatus[key])
+                    {
                         playerData[key].Clan = "[Ready]";
-                    } else {
+                    }
+                    else
+                    {
                         playerData[key].Clan = "[Unready]";
-                    }             
+                    }
                     Server.PrintToChatAll($"PlayerName: {playerData[key].PlayerName} Clan: {playerData[key].Clan}");
                 }
-            } else if (matchStarted) {
-                foreach (var key in playerData.Keys) {
-                    if (playerData[key].TeamNum == 2) {
+            }
+            else if (matchStarted)
+            {
+                foreach (var key in playerData.Keys)
+                {
+                    if (playerData[key].TeamNum == 2)
+                    {
                         playerData[key].Clan = reverseTeamSides["TERRORIST"].teamTag;
-                    } else if (playerData[key].TeamNum == 3) {
+                    }
+                    else if (playerData[key].TeamNum == 3)
+                    {
                         playerData[key].Clan = reverseTeamSides["CT"].teamTag;
                     }
                     Server.PrintToChatAll($"PlayerName: {playerData[key].PlayerName} Clan: {playerData[key].Clan}");
@@ -690,7 +812,8 @@ namespace MatchZy
             }
         }
 
-        private void HandleMatchEnd() {
+        private void HandleMatchEnd()
+        {
             if (!isMatchLive) return;
 
             // This ensures that the mp_match_restart_delay is not shorter than what is required for the GOTV recording to finish.
@@ -699,10 +822,12 @@ namespace MatchZy
             int tvDelay = GetTvDelay();
             int requiredDelay = tvDelay + 15;
             int tvFlushDelay = requiredDelay;
-            if (tvDelay > 0.0) {
+            if (tvDelay > 0.0)
+            {
                 requiredDelay += 10;
             }
-            if (requiredDelay > restartDelay) {
+            if (requiredDelay > restartDelay)
+            {
                 Log($"Extended mp_match_restart_delay from {restartDelay} to {requiredDelay} to ensure GOTV broadcast can finish.");
                 ConVar.Find("mp_match_restart_delay")!.SetValue(requiredDelay);
                 restartDelay = requiredDelay;
@@ -728,7 +853,8 @@ namespace MatchZy
                 StatsTeam2 = new MatchZyStatsTeam(matchzyTeam2.id, matchzyTeam2.teamName, team2SeriesScore, t2score, 0, 0, new List<StatsPlayer>())
             };
 
-            Task.Run(async () => {
+            Task.Run(async () =>
+            {
                 await SendEventAsync(mapResultEvent);
                 await database.SetMapEndData(liveMatchId, currentMapNumber, winnerName, t1score, t2score, team1SeriesScore, team2SeriesScore);
                 await database.WritePlayerStatsToCsv(statsPath, liveMatchId, currentMapNumber);
@@ -745,36 +871,47 @@ namespace MatchZy
 
             int remainingMaps = matchConfig.NumMaps - matchzyTeam1.seriesScore - matchzyTeam2.seriesScore;
             Log($"[HandleMatchEnd] MATCH ENDED, remainingMaps: {remainingMaps}, NumMaps: {matchConfig.NumMaps}, Team1SeriesScore: {matchzyTeam1.seriesScore}, Team2SeriesScore: {matchzyTeam2.seriesScore}");
-            if (matchzyTeam1.seriesScore == matchzyTeam2.seriesScore && remainingMaps <= 0) 
+            if (matchzyTeam1.seriesScore == matchzyTeam2.seriesScore && remainingMaps <= 0)
             {
                 EndSeries(null, restartDelay - 1, t1score, t2score);
             }
-            else if (matchConfig.SeriesCanClinch) {
+            else if (matchConfig.SeriesCanClinch)
+            {
                 int mapsToWinSeries = (matchConfig.NumMaps / 2) + 1;
-                if (matchzyTeam1.seriesScore == mapsToWinSeries) {
+                if (matchzyTeam1.seriesScore == mapsToWinSeries)
+                {
                     EndSeries(winnerName, restartDelay - 1, t1score, t2score);
                     return;
-                } else if (matchzyTeam2.seriesScore == mapsToWinSeries) {
-                    EndSeries(winnerName, restartDelay - 1, t1score, t2score);
-                    return;      
                 }
-            } else if (remainingMaps <= 0) {
+                else if (matchzyTeam2.seriesScore == mapsToWinSeries)
+                {
+                    EndSeries(winnerName, restartDelay - 1, t1score, t2score);
+                    return;
+                }
+            }
+            else if (remainingMaps <= 0)
+            {
                 EndSeries(winnerName, restartDelay - 1, t1score, t2score);
                 return;
             }
-            if (matchzyTeam1.seriesScore > matchzyTeam2.seriesScore) {
+            if (matchzyTeam1.seriesScore > matchzyTeam2.seriesScore)
+            {
                 Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{matchzyTeam1.teamName}{ChatColors.Default} is winning the series {ChatColors.Green}{matchzyTeam1.seriesScore}-{matchzyTeam2.seriesScore}{ChatColors.Default}");
 
-            } else if (matchzyTeam2.seriesScore > matchzyTeam1.seriesScore) {
+            }
+            else if (matchzyTeam2.seriesScore > matchzyTeam1.seriesScore)
+            {
                 Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{matchzyTeam2.teamName}{ChatColors.Default} is winning the series {ChatColors.Green}{matchzyTeam2.seriesScore}-{matchzyTeam1.seriesScore}{ChatColors.Default}");
 
-            } else {
+            }
+            else
+            {
                 Server.PrintToChatAll($"{chatPrefix} The series is tied at {ChatColors.Green}{matchzyTeam1.seriesScore}-{matchzyTeam2.seriesScore}{ChatColors.Default}");
             }
             matchConfig.CurrentMapNumber += 1;
             string nextMap = matchConfig.Maplist[matchConfig.CurrentMapNumber];
 
-            if (isPaused) 
+            if (isPaused)
                 UnpauseMatch();
 
             stopData["ct"] = false;
@@ -782,7 +919,8 @@ namespace MatchZy
 
             KillPhaseTimers();
 
-            AddTimer(restartDelay - 4, () => {
+            AddTimer(restartDelay - 4, () =>
+            {
                 if (!isMatchSetup) return;
                 ChangeMap(nextMap, 3.0f);
                 matchStarted = false;
@@ -792,7 +930,7 @@ namespace MatchZy
                 isWarmup = true;
                 isKnifeRound = false;
                 isSideSelectionPhase = false;
-                isMatchLive = false;    
+                isMatchLive = false;
                 isPractice = false;
                 isDryRun = false;
                 StartWarmup();
@@ -803,26 +941,36 @@ namespace MatchZy
         private void ChangeMap(string mapName, float delay)
         {
             Log($"[ChangeMap] Changing map to {mapName} with delay {delay}");
-            AddTimer(delay, () => {
-                if (long.TryParse(mapName, out _)) {
+            AddTimer(delay, () =>
+            {
+                if (long.TryParse(mapName, out _))
+                {
                     Server.ExecuteCommand($"bot_kick");
                     Server.ExecuteCommand($"host_workshop_map \"{mapName}\"");
-                } else if (Server.IsMapValid(mapName)) {
+                }
+                else if (Server.IsMapValid(mapName))
+                {
                     Server.ExecuteCommand($"bot_kick");
                     Server.ExecuteCommand($"changelevel \"{mapName}\"");
                 }
             });
         }
 
-        private string GetMatchWinnerName() {
+        private string GetMatchWinnerName()
+        {
             (int t1score, int t2score) = GetTeamsScore();
-            if (t1score > t2score) {
+            if (t1score > t2score)
+            {
                 matchzyTeam1.seriesScore++;
                 return matchzyTeam1.teamName;
-            } else if (t2score > t1score) {
+            }
+            else if (t2score > t1score)
+            {
                 matchzyTeam2.seriesScore++;
                 return matchzyTeam2.teamName;
-            } else {
+            }
+            else
+            {
                 return "Draw";
             }
         }
@@ -853,8 +1001,8 @@ namespace MatchZy
             return t1score + t2score;
         }
 
-        public void HandlePostRoundStartEvent(EventRoundStart @event) {
-            if (!matchStarted) return;
+        public void HandlePostRoundStartEvent(EventRoundStart @event)
+        {
             HandleCoaches();
             CreateMatchZyRoundDataBackup();
             InitPlayerDamageInfo();
@@ -870,7 +1018,7 @@ namespace MatchZy
                 matchzyTeam2.coach
             };
 
-            foreach (var coach in coaches) 
+            foreach (var coach in coaches)
             {
                 if (!IsPlayerValid(coach)) continue;
                 // Temporary elevating the player so that they do not block the players
@@ -881,18 +1029,26 @@ namespace MatchZy
 
         public CsTeam GetCoachTeam(CCSPlayerController coach)
         {
-            if (matchzyTeam1.coach == coach) {
-                if (teamSides[matchzyTeam1] == "CT") {
+            if (matchzyTeam1.coach == coach)
+            {
+                if (teamSides[matchzyTeam1] == "CT")
+                {
                     return CsTeam.CounterTerrorist;
-                } else if (teamSides[matchzyTeam1] == "TERRORIST") {
+                }
+                else if (teamSides[matchzyTeam1] == "TERRORIST")
+                {
                     return CsTeam.Terrorist;
                 }
             }
-            if (matchzyTeam2.coach == coach) {
-                if (teamSides[matchzyTeam2] == "CT") {
+            if (matchzyTeam2.coach == coach)
+            {
+                if (teamSides[matchzyTeam2] == "CT")
+                {
                     return CsTeam.CounterTerrorist;
-                } else if (teamSides[matchzyTeam2] == "TERRORIST") {
-                    return  CsTeam.Terrorist;
+                }
+                else if (teamSides[matchzyTeam2] == "TERRORIST")
+                {
+                    return CsTeam.Terrorist;
                 }
             }
             return CsTeam.Spectator;
@@ -901,7 +1057,8 @@ namespace MatchZy
         private void HandleCoachTeam(CCSPlayerController playerController, bool isFreezeTime = false, bool suicide = false)
         {
             CsTeam oldTeam = GetCoachTeam(playerController);
-            if (!(isFreezeTime && playerController.TeamNum == (int)oldTeam)) {
+            if (!(isFreezeTime && playerController.TeamNum == (int)oldTeam))
+            {
                 playerController.ChangeTeam(CsTeam.Spectator);
                 AddTimer(0.01f, () => playerController.ChangeTeam(oldTeam));
             }
@@ -916,9 +1073,12 @@ namespace MatchZy
             }
         }
 
-        private void HandlePostRoundEndEvent(EventRoundEnd @event) {
-            try {
-                if (isMatchLive) {
+        private void HandlePostRoundEndEvent(EventRoundEnd @event)
+        {
+            try
+            {
+                if (isMatchLive)
+                {
                     (int t1score, int t2score) = GetTeamsScore();
                     Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{matchzyTeam1.teamName} [{t1score} - {t2score}] {matchzyTeam2.teamName}");
 
@@ -930,7 +1090,7 @@ namespace MatchZy
                     long matchId = liveMatchId;
                     int ctTeamNum = reverseTeamSides["CT"] == matchzyTeam1 ? 1 : 2;
                     int tTeamNum = reverseTeamSides["TERRORIST"] == matchzyTeam1 ? 1 : 2;
-                    Winner winner  = new(@event.Winner == 3 ? ctTeamNum.ToString() : tTeamNum.ToString(), t1score > t2score ? "team1" : "team2" );
+                    Winner winner = new(@event.Winner == 3 ? ctTeamNum.ToString() : tTeamNum.ToString(), t1score > t2score ? "team1" : "team2");
 
                     var roundEndEvent = new MatchZyRoundEndedEvent
                     {
@@ -944,7 +1104,8 @@ namespace MatchZy
                         StatsTeam2 = new MatchZyStatsTeam(matchzyTeam2.id, matchzyTeam2.teamName, 0, t2score, 0, 0, playerStatsListTeam2),
                     };
 
-                    Task.Run(async () => {
+                    Task.Run(async () =>
+                    {
                         await SendEventAsync(roundEndEvent);
                         await database.UpdatePlayerStatsAsync(matchId, currentMapNumber, playerStatsDictionary);
                         await database.UpdateMapStatsAsync(matchId, currentMapNumber, t1score, t2score);
@@ -956,9 +1117,12 @@ namespace MatchZy
                     Log($"[HandlePostRoundEndEvent] Setting lastBackupFileName to {lastBackupFileName} and lastMatchZyBackupFileName to {lastMatchZyBackupFileName}");
 
                     // One of the team did not use .stop command hence display the proper message after the round has ended.
-                    if (stopData["ct"] && !stopData["t"]) {
+                    if (stopData["ct"] && !stopData["t"])
+                    {
                         Server.PrintToChatAll($"{chatPrefix} The round restore request by {ChatColors.Green}{reverseTeamSides["CT"].teamName}{ChatColors.Default} was cancelled as the round ended");
-                    } else if (!stopData["ct"] && stopData["t"]) {
+                    }
+                    else if (!stopData["ct"] && stopData["t"])
+                    {
                         Server.PrintToChatAll($"{chatPrefix} The round restore request by {ChatColors.Green}{reverseTeamSides["TERRORIST"].teamName}{ChatColors.Default} was cancelled as the round ended");
                     }
 
@@ -969,7 +1133,8 @@ namespace MatchZy
                     bool swapRequired = IsTeamSwapRequired();
 
                     // If isRoundRestoring is true, sides will be swapped from round restore if required!
-                    if (swapRequired && !isRoundRestoring) {
+                    if (swapRequired && !isRoundRestoring)
+                    {
                         SwapSidesInTeamData(false);
                     }
 
@@ -982,7 +1147,8 @@ namespace MatchZy
             }
         }
 
-        public bool IsTeamSwapRequired() {
+        public bool IsTeamSwapRequired()
+        {
             // Handling OTs and side swaps (Referred from Get5)
             var gameRules = Utilities.FindAllEntitiesByDesignerName<CCSGameRulesProxy>("cs_gamerules").First().GameRules!;
             int roundsPlayed = gameRules.TotalRoundsPlayed;
@@ -992,15 +1158,19 @@ namespace MatchZy
 
             bool halftimeEnabled = ConVar.Find("mp_halftime")!.GetPrimitiveValue<bool>();
 
-            if (halftimeEnabled) {
-                if (roundsPlayed == roundsPerHalf) {
+            if (halftimeEnabled)
+            {
+                if (roundsPlayed == roundsPerHalf)
+                {
                     return true;
                 }
                 // Now in OT.
-                if (roundsPlayed >= 2 * roundsPerHalf) {
+                if (roundsPlayed >= 2 * roundsPerHalf)
+                {
                     int otround = roundsPlayed - 2 * roundsPerHalf;  // round 33 -> round 3, etc.
                     // Do side swaps at OT halves (rounds 3, 9, ...)
-                    if ((otround + roundsPerOTHalf) % (2 * roundsPerOTHalf) == 0) {
+                    if ((otround + roundsPerOTHalf) % (2 * roundsPerOTHalf) == 0)
+                    {
                         return true;
                     }
                 }
@@ -1010,19 +1180,27 @@ namespace MatchZy
 
         private void ReplyToUserCommand(CCSPlayerController? player, string message, bool console = false)
         {
-            if (player == null) {
+            if (player == null)
+            {
                 Server.PrintToConsole($"[MatchZy] {message}");
-            } else {
-                if (console) {
+            }
+            else
+            {
+                if (console)
+                {
                     player.PrintToConsole($"[MatchZy] {message}");
-                } else {
+                }
+                else
+                {
                     player.PrintToChat($"{chatPrefix} {message}");
                 }
             }
         }
 
-        private void PauseMatch(CCSPlayerController? player, CommandInfo? command) {
-            if (isMatchLive && isPaused) {
+        private void PauseMatch(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (isMatchLive && isPaused)
+            {
                 // ReplyToUserCommand(player, "Match is already paused!");
                 ReplyToUserCommand(player, Localizer["matchzy.utility.paused"]);
                 return;
@@ -1045,18 +1223,24 @@ namespace MatchZy
                 ReplyToUserCommand(player, Localizer["matchzy.utility.tacticaltimeout"]);
                 return;
             }
-            if (isMatchLive && !isPaused) {
+            if (isMatchLive && !isPaused)
+            {
 
                 string pauseTeamName = "Admin";
                 unpauseData["pauseTeam"] = "Admin";
-                if (player?.TeamNum == 2) {
+                if (player?.TeamNum == 2)
+                {
 
                     pauseTeamName = reverseTeamSides["TERRORIST"].teamName;
                     unpauseData["pauseTeam"] = reverseTeamSides["TERRORIST"].teamName;
-                } else if (player?.TeamNum == 3) {
+                }
+                else if (player?.TeamNum == 3)
+                {
                     pauseTeamName = reverseTeamSides["CT"].teamName;
                     unpauseData["pauseTeam"] = reverseTeamSides["CT"].teamName;
-                } else {
+                }
+                else
+                {
                     return;
                 }
                 PrintToAllChat(Localizer["matchzy.pause.pausedthematch", pauseTeamName]);
@@ -1069,11 +1253,13 @@ namespace MatchZy
         private void ForcePauseMatch(CCSPlayerController? player, CommandInfo? command)
         {
             if (!matchStarted) return;
-            if (!IsPlayerAdmin(player, "css_forcepause", "@css/config")) {
+            if (!IsPlayerAdmin(player, "css_forcepause", "@css/config"))
+            {
                 SendPlayerNotAdminMessage(player);
                 return;
             }
-            if (isMatchLive && isPaused) {
+            if (isMatchLive && isPaused)
+            {
                 // ReplyToUserCommand(player, "Match is already paused!");
                 ReplyToUserCommand(player, Localizer["matchzy.utility.paused"]);
                 return;
@@ -1099,24 +1285,28 @@ namespace MatchZy
             unpauseData["pauseTeam"] = "Admin";
             PrintToAllChat(Localizer["matchzy.pause.adminpausedthematch"]);
             // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}Admin{ChatColors.Default} has paused the match.");
-            if (player == null) {
+            if (player == null)
+            {
                 Server.PrintToConsole($"[MatchZy] {Localizer["matchzy.pause.adminpausedthematch"]}");
-            } 
+            }
             SetMatchPausedFlags();
         }
 
         private void ForceUnpauseMatch(CCSPlayerController? player, CommandInfo? command)
         {
-            if (matchStarted && isPaused) {
-                if (!IsPlayerAdmin(player, "css_forceunpause", "@css/config")) {
+            if (matchStarted && isPaused)
+            {
+                if (!IsPlayerAdmin(player, "css_forceunpause", "@css/config"))
+                {
                     SendPlayerNotAdminMessage(player);
                     return;
                 }
                 PrintToAllChat(Localizer["matchzy.pause.adminunpausedthematch"]);
                 UnpauseMatch();
 
-                if (player == null) {
-                    Server.PrintToConsole("[MatchZy] Admin has unpaused, resuming the match!");
+                if (player == null)
+                {
+                    Server.PrintToConsole("[MatchZy] Admin has unpaused the match, resuming the match!");
                 }
             }
         }
@@ -1127,7 +1317,8 @@ namespace MatchZy
             isPaused = false;
             unpauseData["ct"] = false;
             unpauseData["t"] = false;
-            if (!isPaused && pausedStateTimer != null) {
+            if (!isPaused && pausedStateTimer != null)
+            {
                 pausedStateTimer.Kill();
                 pausedStateTimer = null;
             }
@@ -1141,7 +1332,7 @@ namespace MatchZy
             pausedStateTimer ??= AddTimer(chatTimerDelay, SendPausedStateMessage, TimerFlags.REPEAT);
         }
 
-        private void StartMatchMode() 
+        private void StartMatchMode()
         {
             if (matchStarted || (!isPractice && !isSleep)) return;
             ExecUnpracCommands();
@@ -1161,13 +1352,16 @@ namespace MatchZy
                 absolutePath = Path.Join(Server.GameDirectory + "/csgo/cfg", liveWingmanCfgPath);
                 cfgPath = liveWingmanCfgPath;
             }
-    
+
             // We try to find the CFG in the cfg folder, if it is not there then we execute the default CFG.
-            if (File.Exists(absolutePath)) {
+            if (File.Exists(absolutePath))
+            {
                 Log($"[StartLive] Starting Live! Executing Live CFG from {cfgPath}");
                 Server.ExecuteCommand($"exec {cfgPath}");
                 Server.ExecuteCommand("mp_restartgame 1;mp_warmup_end;");
-            } else {
+            }
+            else
+            {
                 Log($"[StartLive] Starting Live! Live CFG not found in {absolutePath}, using default CFG!");
                 if (gameMode == 2)
                 {
@@ -1182,7 +1376,8 @@ namespace MatchZy
             }
         }
 
-        private void SendPlayerNotAdminMessage(CCSPlayerController? player) {
+        private void SendPlayerNotAdminMessage(CCSPlayerController? player)
+        {
             // ReplyToUserCommand(player, "You do not have permission to use this command!");
             ReplyToUserCommand(player, Localizer["matchzy.utility.dontpermission"]);
         }
@@ -1440,7 +1635,7 @@ namespace MatchZy
             return (gameRules.CTTimeOutActive || gameRules.TerroristTimeOutActive) && gameRules.FreezePeriod;
         }
 
-        public (Dictionary<ulong, Dictionary<string, object>>, List<StatsPlayer>, List<StatsPlayer>)  GetPlayerStatsDict()
+        public (Dictionary<ulong, Dictionary<string, object>>, List<StatsPlayer>, List<StatsPlayer>) GetPlayerStatsDict()
         {
             Dictionary<ulong, Dictionary<string, object>> playerStatsDictionary = new Dictionary<ulong, Dictionary<string, object>>();
             List<StatsPlayer> playerStatsListTeam1 = new();
@@ -1495,9 +1690,12 @@ namespace MatchZy
                     };
 
                     string teamName = "Spectator";
-                    if (player.TeamNum == 3){
+                    if (player.TeamNum == 3)
+                    {
                         teamName = reverseTeamSides["CT"].teamName;
-                    } else if (player.TeamNum == 2 ) {
+                    }
+                    else if (player.TeamNum == 2)
+                    {
                         teamName = reverseTeamSides["TERRORIST"].teamName;
                     }
 
@@ -1554,10 +1752,13 @@ namespace MatchZy
                     int ctTeamNum = reverseTeamSides["CT"] == matchzyTeam1 ? 1 : 2;
                     int tTeamNum = reverseTeamSides["TERRORIST"] == matchzyTeam1 ? 1 : 2;
 
-                    if (player.TeamNum == 3){
+                    if (player.TeamNum == 3)
+                    {
                         if (ctTeamNum == 1) playerStatsListTeam1.Add(statsPlayer);
                         if (ctTeamNum == 2) playerStatsListTeam2.Add(statsPlayer);
-                    } else if (player.TeamNum == 2 ) {
+                    }
+                    else if (player.TeamNum == 2)
+                    {
                         if (tTeamNum == 1) playerStatsListTeam1.Add(statsPlayer);
                         if (tTeamNum == 2) playerStatsListTeam2.Add(statsPlayer);
                     }
@@ -1577,7 +1778,8 @@ namespace MatchZy
             return regex.Replace(input, "");
         }
 
-        private void Log(string message) {
+        private void Log(string message)
+        {
             Console.WriteLine("[MatchZy] " + message);
         }
 
@@ -1600,23 +1802,28 @@ namespace MatchZy
             }
         }
 
-        public int GetGameMode() {
+        public int GetGameMode()
+        {
             var convar = ConVar.Find("game_mode");
-            if (convar != null) {
+            if (convar != null)
+            {
                 return convar.GetPrimitiveValue<int>();
             }
             return -1;
         }
 
-        public int GetGameType() {
+        public int GetGameType()
+        {
             var convar = ConVar.Find("game_type");
-            if (convar != null) {
+            if (convar != null)
+            {
                 return convar.GetPrimitiveValue<int>();
             }
             return -1;
         }
 
-        public void SetCorrectGameMode() {
+        public void SetCorrectGameMode()
+        {
             ConVar.Find("game_mode")!.SetValue(matchConfig.Wingman ? 2 : 1);
             ConVar.Find("game_type")!.SetValue(0); // Classic GameType
         }
@@ -1624,7 +1831,7 @@ namespace MatchZy
         public bool IsMapReloadRequiredForGameMode(bool wingman)
         {
             int expectedMode = wingman ? 2 : 1;
-            if (GetGameMode() != expectedMode || GetGameType() != 0) 
+            if (GetGameMode() != expectedMode || GetGameType() != 0)
             {
                 return true;
             }
@@ -1712,7 +1919,7 @@ namespace MatchZy
                 content.Headers.Add("Get5-MatchId", matchId.ToString());
                 content.Headers.Add("Get5-MapNumber", mapNumber.ToString());
                 content.Headers.Add("Get5-RoundNumber", roundNumber.ToString());
-    
+
 
                 if (!string.IsNullOrEmpty(headerKey) && !string.IsNullOrEmpty(headerValue))
                 {


### PR DESCRIPTION
Based on #189 

- Moved `StartDemoRecording()` call to `StartLive()` function, as this is the most suitable location to start recording a demo.
- Codestyling fixes applied automatically on file save.
- Various fixes to demo recording and match states.

Tested out on Linux server with full BO3 correctly played and recorded (including in-game mapveto).