### PR TITLE
0.8.2: multiple coach, autoteam join, etc

### DIFF
--- a/BackupManagement.cs
+++ b/BackupManagement.cs
@@ -58,6 +58,11 @@ namespace MatchZy
                     ReplyToUserCommand(player, Localizer["matchzy.backup.stoptacticaltimeout"]);
                     return;
                 }
+                if (playerHasTakenDamage && stopCommandNoDamage.Value)
+                {
+                    ReplyToUserCommand(player, Localizer["matchzy.restore.stopcommandrequiresnodamage"]);
+                    return;    
+                }
                 string stopTeamName = "";
                 string remainingStopTeam = "";
                 if (player.TeamNum == 2) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # MatchZy Changelog
 
+# 0.8.2
+
+#### August 25, 2024
+
+- Added capability to have multiple coaches in a team.
+- Coaches will now be invisible, they will drop the bomb on the spawn if they get it and will die 1 second before freezetime ends.
+- If a match is loaded, player will directly join their respective team, skipping the join team menu.
+- Fixed a bug where loading a saved nade would make the player stuck.
+- Added `matchzy_stop_command_no_damage` convar to determine whether the stop command becomes unavailable if a player damages a player from the opposing team.
+- `.map` command can now be used without "de_" prefix for maps. (Example: .map dust2)
+
 # 0.8.1
 
 #### August 17, 2024

--- a/Coach.cs
+++ b/Coach.cs
@@ -1,0 +1,209 @@
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
+using CounterStrikeSharp.API.Modules.Cvars;
+
+namespace MatchZy;
+
+public partial class MatchZy
+{
+
+    public CounterStrikeSharp.API.Modules.Timers.Timer? coachKillTimer = null;
+
+    public HashSet<CCSPlayerController> GetAllCoaches()
+    {
+        HashSet<CCSPlayerController> coaches = new(matchzyTeam1.coach);
+        coaches.UnionWith(matchzyTeam2.coach);
+
+        return coaches;
+    }
+
+    public void HandleCoachCommand(CCSPlayerController? player, string side)
+    {
+        if (!IsPlayerValid(player)) return;
+        if (isPractice)
+        {
+            ReplyToUserCommand(player, "Coach command can only be used in match mode!");
+            return;
+        }
+
+        side = side.Trim().ToLower();
+
+        if (side != "t" && side != "ct")
+        {
+            ReplyToUserCommand(player, "Usage: .coach t or .coach ct");
+            return;
+        }
+
+        if (matchzyTeam1.coach.Contains(player!) || matchzyTeam2.coach.Contains(player!))
+        {
+            ReplyToUserCommand(player, "You are already coaching a team!");
+            return;
+        }
+
+        Team matchZyCoachTeam;
+
+        if (side == "t")
+        {
+            matchZyCoachTeam = reverseTeamSides["TERRORIST"];
+        }
+        else if (side == "ct")
+        {
+            matchZyCoachTeam = reverseTeamSides["CT"];
+        }
+        else
+        {
+            return;
+        }
+
+        // if (matchZyCoachTeam.coach != null) {
+        //     ReplyToUserCommand(player, "Coach slot for this team has been already taken!");
+        //     return;
+        // }
+
+        matchZyCoachTeam.coach.Add(player!);
+        player!.Clan = $"[{matchZyCoachTeam.teamName} COACH]";
+        if (player.InGameMoneyServices != null) player.InGameMoneyServices.Account = 0;
+        ReplyToUserCommand(player, $"You are now coaching {matchZyCoachTeam.teamName}! Use .uncoach to stop coaching");
+        PrintToAllChat($"{ChatColors.Green}{player.PlayerName}{ChatColors.Default} is now coaching {ChatColors.Green}{matchZyCoachTeam.teamName}{ChatColors.Default}!");
+    }
+
+    public void HandleCoaches()
+    {
+        coachKillTimer?.Kill();
+        coachKillTimer = null;
+        int freezeTime = ConVar.Find("mp_freezetime")!.GetPrimitiveValue<int>();
+        coachKillTimer ??= AddTimer(freezeTime - 1.5f, KillCoaches);
+        HashSet<CCSPlayerController> coaches = GetAllCoaches();
+
+        foreach (var coach in coaches)
+        {
+            if (!IsPlayerValid(coach)) continue;
+            Team coachTeam = matchzyTeam1.coach.Contains(coach) ? matchzyTeam1 : matchzyTeam2;
+            int coachTeamNum = teamSides[coachTeam] == "CT" ? 3 : 2;
+            coach.InGameMoneyServices!.Account = 0;
+
+            AddTimer(0.5f, () => HandleCoachTeam(coach));
+
+            coach.ActionTrackingServices!.MatchStats.Kills = 0;
+            coach.ActionTrackingServices!.MatchStats.Deaths = 0;
+            coach.ActionTrackingServices!.MatchStats.Assists = 0;
+            coach.ActionTrackingServices!.MatchStats.Damage = 0;
+
+            bool isCompetitiveSpawn = false;
+
+            Position coachPosition = new(coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsOrigin, coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsRotation);
+            List<Position> teamPositions = spawnsData[(byte)coachTeamNum];
+
+            // Elevating the coach so that they don't block the players.
+            coach!.PlayerPawn.Value!.Teleport(new Vector(coach.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.X, coach.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.Y, coach.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.Z + 75.0f), coach.PlayerPawn.Value.EyeAngles, new Vector(0, 0, 0));
+            coach.PlayerPawn.Value!.MoveType = MoveType_t.MOVETYPE_NONE;
+            coach.PlayerPawn.Value!.ActualMoveType = MoveType_t.MOVETYPE_NONE;
+
+            SetPlayerInvisible(player: coach, setWeaponsInvisible: false);
+
+            foreach (Position position in teamPositions)
+            {
+                if (position.Equals(coachPosition))
+                {
+                    isCompetitiveSpawn = true;
+                    break;
+                }
+            }
+            if (isCompetitiveSpawn)
+            {
+                foreach (var key in playerData.Keys)
+                {
+                    CCSPlayerController player = playerData[key];
+                    if (!IsPlayerValid(player) || coaches.Contains(player) || player.TeamNum != (byte)coachTeamNum) continue;
+                    bool playerOnCompetitiveSpawn = false;
+                    Position playerPosition = new(player.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsOrigin, player.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsRotation);
+                    foreach (Position position in teamPositions)
+                    {
+                        if (position.Equals(playerPosition))
+                        {
+                            playerOnCompetitiveSpawn = true;
+                            break;
+                        }
+                    }
+                    // No need to swap the player if they are already on a competitive spawn.
+                    if (playerOnCompetitiveSpawn) continue;
+                    // Swapping positions of the coach and the player so that the coach doesn't take any competitive spawn.
+                    AddTimer(0.1f, () =>
+                    {
+                        coach!.PlayerPawn.Value.Teleport(new Vector(playerPosition.PlayerPosition.X, playerPosition.PlayerPosition.Y, playerPosition.PlayerPosition.Z + 150.0f), playerPosition.PlayerAngle, new Vector(0, 0, 0));
+                        player!.PlayerPawn.Value.Teleport(coachPosition.PlayerPosition, coachPosition.PlayerAngle, new Vector(0, 0, 0));
+                    });
+                }
+            }
+            HandleCoachWeapons(coach);
+        }
+    }
+
+    private void HandleCoachWeapons(CCSPlayerController coach)
+    {
+        if (!IsPlayerValid(coach)) return;
+        DropWeaponByDesignerName(coach, "weapon_c4");
+        coach.RemoveWeapons();
+    }
+
+    public CsTeam GetCoachTeam(CCSPlayerController coach)
+    {
+        if (matchzyTeam1.coach.Contains(coach))
+        {
+            if (teamSides[matchzyTeam1] == "CT")
+            {
+                return CsTeam.CounterTerrorist;
+            }
+            else if (teamSides[matchzyTeam1] == "TERRORIST")
+            {
+                return CsTeam.Terrorist;
+            }
+        }
+        if (matchzyTeam2.coach.Contains(coach))
+        {
+            if (teamSides[matchzyTeam2] == "CT")
+            {
+                return CsTeam.CounterTerrorist;
+            }
+            else if (teamSides[matchzyTeam2] == "TERRORIST")
+            {
+                return CsTeam.Terrorist;
+            }
+        }
+        return CsTeam.Spectator;
+    }
+
+    private void HandleCoachTeam(CCSPlayerController playerController)
+    {
+        CsTeam oldTeam = GetCoachTeam(playerController);
+        if (playerController.Team != oldTeam)
+        {
+            playerController.ChangeTeam(CsTeam.Spectator);
+            AddTimer(0.01f, () => playerController.ChangeTeam(oldTeam));
+        }
+        if (playerController.InGameMoneyServices != null) playerController.InGameMoneyServices.Account = 0;
+    }
+
+    private void KillCoaches()
+    {
+        HashSet<CCSPlayerController> coaches = GetAllCoaches();
+        string suicidePenalty = GetConvarStringValue(ConVar.Find("mp_suicide_penalty"));
+        string deathDropGunEnabled = GetConvarStringValue(ConVar.Find("mp_death_drop_gun"));
+        string specFreezeTime = GetConvarStringValue(ConVar.Find("spec_freeze_time"));
+        string specFreezeTimeLock = GetConvarStringValue(ConVar.Find("spec_freeze_time_lock"));
+        string specFreezeDeathanim = GetConvarStringValue(ConVar.Find("spec_freeze_deathanim_time"));
+        Server.ExecuteCommand("mp_suicide_penalty 0; mp_death_drop_gun 0;spec_freeze_time 0; spec_freeze_time_lock 0; spec_freeze_deathanim_time 0;");
+
+        // Adding timer to make sure above commands are executed successfully.
+        AddTimer(0.5f, () =>
+        {
+            foreach (var coach in coaches)
+            {
+                if (!IsPlayerValid(coach)) continue;
+                coach.PlayerPawn.Value!.CommitSuicide(explode: false, force: true);
+            }
+            Server.ExecuteCommand($"mp_suicide_penalty {suicidePenalty}; mp_death_drop_gun {deathDropGunEnabled}; spec_freeze_time {specFreezeTime}; spec_freeze_time_lock {specFreezeTimeLock}; spec_freeze_deathanim_time {specFreezeDeathanim};");
+        });
+    }
+}

--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -25,6 +25,8 @@ namespace MatchZy
 
         public FakeConVar<bool> enableDamageReport = new("matchzy_enable_damage_report", "Whether to show damage report after each round or not. Default: true", true);
 
+        public FakeConVar<bool> stopCommandNoDamage = new("matchzy_stop_command_no_damage", "Whether the stop command becomes unavailable if a player damages a player from the opposing team.", false);
+
         [ConsoleCommand("matchzy_whitelist_enabled_default", "Whether Whitelist is enabled by default or not. Default value: false")]
         public void MatchZyWLConvar(CCSPlayerController? player, CommandInfo command)
         {

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -120,17 +120,14 @@ namespace MatchZy
         [ConsoleCommand("css_stay", "Stays after knife round")]
         public void OnTeamStay(CCSPlayerController? player, CommandInfo? command)
         {
-            if (player == null) return;
+            if (player == null || !isSideSelectionPhase) return;
 
             Log($"[!stay command] {player.UserId}, TeamNum: {player.TeamNum}, knifeWinner: {knifeWinner}, isSideSelectionPhase: {isSideSelectionPhase}");
-            if (isSideSelectionPhase)
+            if (player.TeamNum == knifeWinner)
             {
-                if (player.TeamNum == knifeWinner)
-                {
-                    PrintToAllChat(Localizer["matchzy.knife.decidedtostay", knifeWinnerName]);
-                    // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{knifeWinnerName}{ChatColors.Default} has decided to stay!");
-                    StartLive();
-                }
+                PrintToAllChat(Localizer["matchzy.knife.decidedtostay", knifeWinnerName]);
+                // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{knifeWinnerName}{ChatColors.Default} has decided to stay!");
+                StartLive();
             }
         }
 
@@ -138,19 +135,17 @@ namespace MatchZy
         [ConsoleCommand("css_swap", "Switch after knife round")]
         public void OnTeamSwitch(CCSPlayerController? player, CommandInfo? command)
         {
-            if (player == null) return;
+            if (player == null || !isSideSelectionPhase) return;
 
             Log($"[!switch command] {player.UserId}, TeamNum: {player.TeamNum}, knifeWinner: {knifeWinner}, isSideSelectionPhase: {isSideSelectionPhase}");
-            if (isSideSelectionPhase)
+
+            if (player.TeamNum == knifeWinner)
             {
-                if (player.TeamNum == knifeWinner)
-                {
-                    Server.ExecuteCommand("mp_swapteams;");
-                    SwapSidesInTeamData(true);
-                    PrintToAllChat(Localizer["matchzy.knife.decidedtoswitch", knifeWinnerName]);
-                    // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{knifeWinnerName}{ChatColors.Default} has decided to switch!");
-                    StartLive();
-                }
+                Server.ExecuteCommand("mp_swapteams;");
+                SwapSidesInTeamData(true);
+                PrintToAllChat(Localizer["matchzy.knife.decidedtoswitch", knifeWinnerName]);
+                // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{knifeWinnerName}{ChatColors.Default} has decided to switch!");
+                StartLive();
             }
         }
 

--- a/DemoManagement.cs
+++ b/DemoManagement.cs
@@ -66,7 +66,6 @@ namespace MatchZy
                 if (isDemoRecording)
                 {
                     Server.ExecuteCommand($"tv_stoprecord");
-                    isDemoRecording = false;
                 }
                 isDemoRecording = false;
                 AddTimer(15, () =>

--- a/MapVeto.cs
+++ b/MapVeto.cs
@@ -647,6 +647,14 @@ namespace MatchZy
             }
         }
 
+        public void SkipVeto()
+        {
+            isWarmup = true;
+            readyAvailable = true;
+            isPreVeto = false;
+            isVeto = false;
+            StartWarmup();
+        }
     }
 }
 

--- a/MatchManagement.cs
+++ b/MatchManagement.cs
@@ -508,12 +508,18 @@ namespace MatchZy
                 matchzyTeam1.teamName = teamName;
                 teamSides[matchzyTeam1] = "CT";
                 reverseTeamSides["CT"] = matchzyTeam1;
-                if (matchzyTeam1.coach != null) matchzyTeam1.coach.Clan = $"[{matchzyTeam1.teamName} COACH]";
+                foreach (var coach in matchzyTeam1.coach)
+                {
+                    coach.Clan = $"[{matchzyTeam1.teamName} COACH]";
+                }
             } else if (teamNum == 2) {
                 matchzyTeam2.teamName = teamName;
                 teamSides[matchzyTeam2] = "TERRORIST";
                 reverseTeamSides["TERRORIST"] = matchzyTeam2;
-                if (matchzyTeam2.coach != null) matchzyTeam2.coach.Clan = $"[{matchzyTeam2.teamName} COACH]";
+                foreach (var coach in matchzyTeam2.coach)
+                {
+                    coach.Clan = $"[{matchzyTeam2.teamName} COACH]";
+                }
             }
             Server.ExecuteCommand($"mp_teamname_{teamNum} {teamName};");
         }

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -314,7 +314,7 @@ namespace MatchZy
 
                     savedNadesDict[playerSteamID][lineupName] = new Dictionary<string, string>
                     {
-                        { "LineupPos", $"{playerPos.X} {playerPos.Y} {playerPos.Z}" },
+                        { "LineupPos", $"{playerPos.X} {playerPos.Y} {playerPos.Z+4}" },
                         { "LineupAng", $"{playerAngle.X} {playerAngle.Y} {playerAngle.Z}" },
                         { "Desc", lineupDesc },
                         { "Map", currentMapName },
@@ -1018,7 +1018,7 @@ namespace MatchZy
             var player = @event.Userid;
             if (!IsPlayerValid(player)) return HookResult.Continue;
 
-            if (matchStarted && (matchzyTeam1.coach == player || matchzyTeam2.coach == player))
+            if (matchStarted && (matchzyTeam1.coach.Contains(player!) || matchzyTeam2.coach.Contains(player!)))
             {
                 player!.InGameMoneyServices!.Account = 0;
 
@@ -1508,7 +1508,7 @@ namespace MatchZy
             if (IsValidPositionForLastGrenade(player!, 1))
             {
                 // PrintToPlayerChat(player!, $"Index of last thrown grenade: {lastGrenadesData[player!.UserId!.Value].Count}");
-                PrintToPlayerChat(player, Localizer["matchzy.pm.indexlastgrenade", $"{lastGrenadesData[player!.UserId!.Value].Count}"]);
+                PrintToPlayerChat(player!, Localizer["matchzy.pm.indexlastgrenade", $"{lastGrenadesData[player!.UserId!.Value].Count}"]);
             } 
         }
 

--- a/Teams.cs
+++ b/Teams.cs
@@ -1,10 +1,9 @@
-using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Commands;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
-using CounterStrikeSharp.API.Modules.Utils;
 using Newtonsoft.Json.Linq;
 using System.Text.Json.Serialization;
+using CounterStrikeSharp.API;
 
 namespace MatchZy
 {
@@ -26,7 +25,8 @@ namespace MatchZy
         [JsonPropertyName("teamplayers")]
         public JToken? teamPlayers;
 
-        public CCSPlayerController? coach;
+        [JsonIgnore, Newtonsoft.Json.JsonIgnore]
+        public HashSet<CCSPlayerController> coach = [];
 
         [JsonPropertyName("seriesscore")]
         public int seriesScore = 0;
@@ -49,22 +49,23 @@ namespace MatchZy
                 return;
             }
 
-            Team matchZyCoachTeam;
-
-            if (matchzyTeam1.coach == player) {
-                matchZyCoachTeam = matchzyTeam1;
+            if (matchzyTeam1.coach.Contains(player)) {
+                player.Clan = "";
+                matchzyTeam1.coach.Remove(player);
+                SetPlayerVisible(player);
             }
-            else if (matchzyTeam2.coach == player) {
-                matchZyCoachTeam = matchzyTeam2;
+            else if (matchzyTeam2.coach.Contains(player)) {
+                player.Clan = "";
+                matchzyTeam2.coach.Remove(player);
+                SetPlayerVisible(player);
             }
             else {
                 ReplyToUserCommand(player, "You are not coaching any team!");
                 return;
             }
 
-            player.Clan = "";
             if (player.InGameMoneyServices != null) player.InGameMoneyServices.Account = 0;
-            matchZyCoachTeam.coach = null;
+
             ReplyToUserCommand(player, "You are now not coaching any team!");
         }
 
@@ -84,7 +85,7 @@ namespace MatchZy
             }
             if (command.ArgCount < 3)
             {
-                command.ReplyToCommand("Usage: matchzy_addplayertoteam <steam64> <team> \"<name>\"");
+                command.ReplyToCommand("Usage: matchzy_addplayer <steam64> <team> \"<name>\"");
                 return; 
             }
 
@@ -114,142 +115,44 @@ namespace MatchZy
             command.ReplyToCommand($"Player {playerName} added to {playerTeam} successfully!");
         }
 
-        public void HandleCoachCommand(CCSPlayerController? player, string side) {
-            if (player == null || !player.PlayerPawn.IsValid) return;
-            if (isPractice) {
-                ReplyToUserCommand(player, "Coach command can only be used in match mode!");
-                return;
-            }
-
-            side = side.Trim().ToLower();
-
-            if (side != "t" && side != "ct") {
-                ReplyToUserCommand(player, "Usage: .coach t or .coach ct");
-                return;
-            }
-
-            if (matchzyTeam1.coach == player || matchzyTeam2.coach == player) 
-            {
-                ReplyToUserCommand(player, "You are already coaching a team!");
-                return;
-            }
-
-            Team matchZyCoachTeam;
-
-            if (side == "t") {
-                matchZyCoachTeam = reverseTeamSides["TERRORIST"];
-            } else if (side == "ct") {
-                matchZyCoachTeam = reverseTeamSides["CT"];
-            } else {
-                return;
-            }
-
-            if (matchZyCoachTeam.coach != null) {
-                ReplyToUserCommand(player, "Coach slot for this team has been already taken!");
-                return;
-            }
-
-            matchZyCoachTeam.coach = player;
-            player.Clan = $"[{matchZyCoachTeam.teamName} COACH]";
-            if (player.InGameMoneyServices != null) player.InGameMoneyServices.Account = 0;
-            ReplyToUserCommand(player, $"You are now coaching {matchZyCoachTeam.teamName}! Use .uncoach to stop coaching");
-            Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{player.PlayerName}{ChatColors.Default} is now coaching {ChatColors.Green}{matchZyCoachTeam.teamName}{ChatColors.Default}!");
-        }
-
-        public void HandleCoaches() 
+        [ConsoleCommand("matchzy_removeplayer", "Adds player to the provided team")]
+        [ConsoleCommand("get5_removeplayer", "Adds player to the provided team")]
+        [CommandHelper(minArgs: 1, usage: "<steam64>")]
+        public void OnRemovePlayerCommand(CCSPlayerController? player, CommandInfo? command)
         {
-            List<CCSPlayerController?> coaches = new()
-            {
-                matchzyTeam1.coach,
-                matchzyTeam2.coach
-            };
-
-            foreach (var coach in coaches) 
-            {
-                if (coach == null) continue;
-                Team coachTeam = coach == matchzyTeam1.coach ? matchzyTeam1 : matchzyTeam2;
-                int coachTeamNum = teamSides[coachTeam] == "CT" ? 3 : 2;
-                coach.InGameMoneyServices!.Account = 0;
-                AddTimer(0.5f, () => HandleCoachTeam(coach, true));
-
-                coach.ActionTrackingServices!.MatchStats.Kills = 0;
-                coach.ActionTrackingServices!.MatchStats.Deaths = 0;
-                coach.ActionTrackingServices!.MatchStats.Assists = 0;
-                coach.ActionTrackingServices!.MatchStats.Damage = 0;
-
-                bool isCompetitiveSpawn = false;
-
-                Position coachPosition = new(coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsOrigin, coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsRotation);
-                List<Position> teamPositions = spawnsData[(byte)coachTeamNum];
-
-                // Elevating the coach so that they don't block the players.
-                coach!.PlayerPawn.Value!.Teleport(new Vector(coach.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.X, coach.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.Y, coach.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin.Z + 150.0f), coach.PlayerPawn.Value.EyeAngles, new Vector(0, 0, 0));
-                coach.PlayerPawn.Value!.MoveType = MoveType_t.MOVETYPE_NONE;
-                coach.PlayerPawn.Value!.ActualMoveType = MoveType_t.MOVETYPE_NONE;
-
-                foreach (Position position in teamPositions) 
-                {
-                    if (position.Equals(coachPosition)) 
-                    {
-                        isCompetitiveSpawn = true;
-                        break;
-                    }
-                }
-                if (isCompetitiveSpawn)
-                {
-                    foreach (var key in playerData.Keys)
-                    {
-                        CCSPlayerController player = playerData[key];
-                        if (!IsPlayerValid(player) || player == coach || player.TeamNum != (byte)coachTeamNum) continue;
-                        bool playerOnCompetitiveSpawn = false;
-                        Position playerPosition = new(player.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsOrigin, player.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsRotation);
-                        foreach (Position position in teamPositions)
-                        {
-                            if (position.Equals(playerPosition))
-                            {
-                                playerOnCompetitiveSpawn = true;
-                                break;
-                            }
-                        }
-                        // No need to swap the player if they are already on a competitive spawn.
-                        if (playerOnCompetitiveSpawn) continue;
-                        // Swapping positions of the coach and the player so that the coach doesn't take any competitive spawn.
-                        AddTimer(0.1f, () => 
-                        {
-                            coach!.PlayerPawn.Value.Teleport(new Vector(playerPosition.PlayerPosition.X, playerPosition.PlayerPosition.Y, playerPosition.PlayerPosition.Z + 150.0f), playerPosition.PlayerAngle, new Vector(0, 0, 0));
-                            player!.PlayerPawn.Value.Teleport(coachPosition.PlayerPosition, coachPosition.PlayerAngle, new Vector(0, 0, 0));
-                        });
-                    }
-                }
-                HandleCoachWeapons(coach);
+            if (player != null || command == null) return;
+            if (!isMatchSetup) {
+                command.ReplyToCommand("No match is setup!");
+                return;
             }
-        }
-
-        private void HandleCoachWeapons(CCSPlayerController coach)
-        {
-            if (!IsPlayerValid(coach)) return;
-
-            var coachWeaponServices = coach.PlayerPawn.Value!.WeaponServices;
-            if (coachWeaponServices == null) return;
-            bool coachHasC4 = false;
-            foreach (var weapon in coachWeaponServices.MyWeapons)
+            if (IsHalfTimePhase())
             {
-                if (weapon == null || !weapon.IsValid || weapon.Value == null || !weapon.Value.IsValid) continue;
-                if (weapon.Value.DesignerName == "weapon_c4") coachHasC4 = true;
+                command.ReplyToCommand("Cannot add players during halftime. Please wait until the next round starts.");
+                return;
             }
 
-            coach.RemoveWeapons();
+            string arg = command.GetArg(1);
 
-            if (!coachHasC4) return;
-
-            // Giving a random player from coach's team the C4
-            var randomKeys = playerData.Keys.OrderBy(k => Guid.NewGuid());
-            foreach (var key in randomKeys)
+            if (!ulong.TryParse(arg, out ulong steamId))
             {
-                CCSPlayerController player = playerData[key];
-                if (!IsPlayerValid(player) || player == coach || player.TeamNum != coach.TeamNum) continue;
-                player.GiveNamedItem("weapon_c4");
-                break;
+                command.ReplyToCommand($"Invalid Steam64");
+            }
+
+            bool success = RemovePlayerFromTeam(steamId.ToString());
+            if (success)
+            {
+                command.ReplyToCommand($"Successfully removed player {steamId}");
+                CCSPlayerController? removedPlayer = Utilities.GetPlayerFromSteamId(steamId);
+                if (IsPlayerValid(removedPlayer))
+                {
+                    Log($"Kicking player {removedPlayer!.PlayerName} - Not a player in this game (removed).");
+                    PrintToAllChat($"Kicking player {removedPlayer!.PlayerName} - Not a player in this game.");
+                    KickPlayer(removedPlayer);
+                }
+            }
+            else
+            {
+                command.ReplyToCommand($"Player {steamId} not found in any team or the Steam ID was invalid.");
             }
         }
 
@@ -270,6 +173,27 @@ namespace MatchZy
                 jArrayTeam.Add(name);
                 LoadClientNames();
                 return true;
+            }
+            return false;
+        }
+
+        public bool RemovePlayerFromTeam(string steamId)
+        {
+            List<JToken?> teams = [matchzyTeam1.teamPlayers, matchzyTeam2.teamPlayers, matchConfig.Spectators];
+
+            foreach (var team in teams)
+            {
+                if (team is null) continue;
+                if (team is JObject jObjectTeam)
+                {
+                    jObjectTeam.Remove(steamId);
+                    return true;
+                }
+                else if (team is JArray jArrayTeam)
+                {
+                    jArrayTeam.Remove(steamId);
+                    return true;
+                }
             }
             return false;
         }

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -28,6 +28,9 @@ matchzy_demo_name_format "{TIME}_{MATCH_ID}_{MAP}_{TEAM1}_vs_{TEAM2}"
 // But in some cases, this may not be reliable hence default value is false
 matchzy_stop_command_available false
 
+// Whether the stop command becomes unavailable if a player damages a player from the opposing team. Default: false
+matchzy_stop_command_no_damage false
+
 // Whether to use !pause/.pause command for tactical pause or normal pause (unpauses only when both teams use unpause command, for admin force-unpauses the game)
 // Default value: false
 matchzy_use_pause_command_for_tactical_pause false

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -59,6 +59,9 @@ Again, inside `csgo/cfg/MatchZy`, a file named `config.cfg` should be present. T
 ####`matchzy_stop_command_available`
 :   Whether !stop/.stop command to restore the backup of the current round is enabled by default or not.<br>**`Default: false`**
 
+####`matchzy_stop_command_no_damage`
+:   Whether the stop command becomes unavailable if a player damages a player from the opposing team.<br>**`Default: false`**
+
 ####`matchzy_pause_after_restore`
 :   Whether to pause the match after round restore or not. Players can unpause the match using !unpause/.unpause. (Both the teams will have to use unpause command) or admins can use `.fup` to force-unpause the game<br>**`Default: true`**
 
@@ -140,6 +143,12 @@ Example: `matchzy_demo_upload_url "https://your-website.com/upload-endpoint"` <b
 
 ####`matchzy_enable_damage_report`
 :   Whether to show damage report after each round or not. **`Default: "true"`**
+
+####`matchzy_addplayer <steam64> <team1|team2|spec> [name]`
+:   Adds a Steam64 to the provided team. The name parameter locks the player's name.
+
+####`matchzy_removeplayer <steam64>`
+:   Removes a Steam64 from all teams
 
 ### Configuring Warmup/Knife/Live/Prac CFGs
 Again, inside `csgo/cfg/MatchZy`, files named `warmup.cfg`, `knife.cfg`, `live.cfg` and `prac.cfg` should be present. These configs are executed when Warmup, Knife, Live and Practice Mode is started respectively.

--- a/lang/de.json
+++ b/lang/de.json
@@ -24,6 +24,7 @@
     "matchzy.restore.teamwantstorestore": "{green}{0}{default} möchte die aktuelle Runde wiederholen. {green}{1}{default}, bitte schreibt !stop in den Chat, um zuzustimmen.",
     "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
     "matchzy.restore.restoredsuccessfully": "Das Backup der Runde wurde erfolgreich geladen: {0}",
+    "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
 
     "matchzy.backup.stopduringhalftime": "You cannot use this command during halftime.",
     "matchzy.backup.stopmatchended": "You cannot use this command after the game has ended.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -24,6 +24,7 @@
   "matchzy.restore.teamwantstorestore": "{green}{0}{default} wants to restore the game to the beginning of the current round. {green}{1}{default}, please write !stop to confirm.",
   "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
   "matchzy.restore.restoredsuccessfully": "Backup restored successfully from file: {0}",
+  "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
 
   "matchzy.backup.stopduringhalftime": "You cannot use this command during halftime.",
   "matchzy.backup.stopmatchended": "You cannot use this command after the game has ended.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -24,6 +24,7 @@
     "matchzy.restore.teamwantstorestore": "{green}{0}{default} souhaite restaurer le jeu au début du round actuel. {green}{1}{default}, veuillez écrire !stop pour confirmer.",
     "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
     "matchzy.restore.restoredsuccessfully": "Fichier de sauvegarde restauré avec succès: {0}",
+    "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
 
     "matchzy.backup.stopduringhalftime": "You cannot use this command during halftime.",
     "matchzy.backup.stopmatchended": "You cannot use this command after the game has ended.",

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -21,6 +21,7 @@
   "matchzy.restore.teamwantstorestore": "{green}{0}{default} vissza szeretné állítani a játékot az aktuális kör elejére. {green}{1}{default}, kérlek írd be: !stop a megerősítéshez.",
   "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
   "matchzy.restore.restoredsuccessfully": "Biztonsági mentés sikeresen visszaállítva: {0}",
+  "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
   "matchzy.backup.stopduringhalftime": "Nem használhatod ezt a parancsot a félidőben.",
   "matchzy.backup.stopmatchended": "Nem használhatod ezt a parancsot a meccs vége után.",
   "matchzy.backup.stoptacticaltimeout": "Nem használhatod ezt a parancsot taktikai szünet közben.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -24,6 +24,7 @@
   "matchzy.restore.teamwantstorestore": "{green}{0}{default} ゲームを現在のラウンドの始めに戻します。 {green}{1}{default}, 確認するには !stop と入力してください。",
   "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
   "matchzy.restore.restoredsuccessfully": "バックアップファイルが正常に復元されました: {0}",
+  "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
 
   "matchzy.backup.stopduringhalftime": "ハーフタイム中はこのコマンドは使用できません。",
   "matchzy.backup.stopmatchended": "ゲーム終了後はこのコマンドは使用できません。",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -24,6 +24,7 @@
   "matchzy.restore.teamwantstorestore": "{green}{0}{default} quer restaurar o jogo para o início da rodada atual. {green}{1}{default}, por favor, escreva {green}!stop{default} para confirmar.",
   "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
   "matchzy.restore.restoredsuccessfully": "Arquivo de backup restaurado com sucesso: {0}",
+  "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
 
   "matchzy.backup.stopduringhalftime": "Você não pode usar este comando durante o intervalo.",
   "matchzy.backup.stopmatchended": "Você não pode usar este comando depois que o jogo terminou.",

--- a/lang/pt-PT.json
+++ b/lang/pt-PT.json
@@ -24,6 +24,7 @@
   "matchzy.restore.teamwantstorestore": "{green}{0}{default} quer reinicar para o início desta ronda. {green}{1}{default}, escreva !stop para confirmar.",
   "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
   "matchzy.restore.restoredsuccessfully": "Ficheiro Backup restaurado com sucesso: {0}",
+  "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
 
   "matchzy.backup.stopduringhalftime": "Não podes usar este comando durante um intervalo.",
   "matchzy.backup.stopmatchended": "Não podes usar este comando depois da partida ter terminado.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -21,6 +21,7 @@
     "matchzy.restore.teamwantstorestore": "{green}{0}{default} хочет восстановить игру до начала текущего раунда. {green}{1}{default}, пожалуйста, напишите !stop для подтверждения.",
     "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
     "matchzy.restore.restoredsuccessfully": "Резервная копия успешно восстановлена: {0}",
+    "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
     "matchzy.backup.stopduringhalftime": "Вы не можете использовать эту команду во время смены сторон.",
     "matchzy.backup.stopmatchended": "Вы не можете использовать эту команду после окончания игры.",
     "matchzy.backup.stoptacticaltimeout": "Вы не можете использовать эту команду, когда активен тактический перерыв.",

--- a/lang/uz.json
+++ b/lang/uz.json
@@ -24,6 +24,7 @@
   "matchzy.restore.teamwantstorestore": "{green}{0}{default} oʻyinni joriy raundning boshiga tiklamoqchi. {green}{1}{default}, tasdiqlash uchun !stop yozing.",
   "matchzy.restore.loadedsuccessfully": "Zaxira fayli muvaffaqiyatli yuklandi: {0}",
   "matchzy.restore.restoredsuccessfully": "Zaxira fayli muvaffaqiyatli tiklandi: {0}",
+  "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
 
   "matchzy.backup.stopduringhalftime": "Tanaffus paytida ushbu buyruqdan foydalana olmaysiz.",
   "matchzy.backup.stopmatchended": "Oʻyin tugagandan soʻng siz ushbu buyruqdan foydalana olmaysiz.",

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -24,6 +24,7 @@
     "matchzy.restore.teamwantstorestore": "{green}{0}{default} 想要回溯游戏至本回合开始时。 {green}{1}{default}, 请输入 !stop 来确定。",
     "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
     "matchzy.restore.restoredsuccessfully": "成功恢复备份文件: {0}",
+    "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
 
     "matchzy.backup.stopduringhalftime": "你不能在半场期间使用此命令.",
     "matchzy.backup.stopmatchended": "你不能在比赛结束后使用此命令.",

--- a/lang/zh-Hant.json
+++ b/lang/zh-Hant.json
@@ -24,6 +24,7 @@
   "matchzy.restore.teamwantstorestore": "{green}{0}{default} 想要回溯遊戲至本回合開始時。 {green}{1}{default}, 請輸入 !stop 來確定。",
   "matchzy.restore.loadedsuccessfully": "Backup file loaded successfully: {0}",
   "matchzy.restore.restoredsuccessfully": "成功恢復備份文件: {0}",
+  "matchzy.restore.stopcommandrequiresnodamage": "A request to restart the round cannot be given once a player has damaged any opposing player.",
 
   "matchzy.backup.stopduringhalftime": "你不能在半場期間使用此命令。",
   "matchzy.backup.stopmatchended": "你不能在比賽結束後使用此命令。",


### PR DESCRIPTION
- Added capability to have multiple coaches in a team.
- Coaches will now be invisible, they will drop the bomb on the spawn if they get it and will die 1 second before freezetime ends.
- If a match is loaded, player will directly join their respective team, skipping the join team menu.
- Fixed a bug where loading a saved nade would make the player stuck.
- Added `matchzy_stop_command_no_damage` convar to determine whether the stop command becomes unavailable if a player damages a player from the opposing team.
- `.map` command can now be used without "de_" prefix for maps. (Example: .map dust2)