### PR TITLE
0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `matchzy_match_start_message` convar to configure message to show when the match starts. Use $$$ to break message into multiple lines.
 - Some improvements and guard checks in coach system
 - Fixed `matchzy_hostname_format` not getting disabled on setting its value to ""
+- Fixed winner side in `round_end` event
 
 # 0.8.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # MatchZy Changelog
 
+# 0.8.5
+
+#### August 27, 2024
+
+- Added `matchzy_match_start_message` convar to configure message to show when the match starts. Use $$$ to break message into multiple lines.
+- Some improvements and guard checks in coach system
+- Fixed `matchzy_hostname_format` not getting disabled on setting its value to ""
+
 # 0.8.4
 
 #### August 27, 2024

--- a/Coach.cs
+++ b/Coach.cs
@@ -72,10 +72,11 @@ public partial class MatchZy
     {
         coachKillTimer?.Kill();
         coachKillTimer = null;
+        HashSet<CCSPlayerController> coaches = GetAllCoaches();
+        if (coaches.Count == 0) return;
         int freezeTime = ConVar.Find("mp_freezetime")!.GetPrimitiveValue<int>();
         freezeTime = freezeTime > 2 ? freezeTime: 2;
         coachKillTimer ??= AddTimer(freezeTime - 1.5f, KillCoaches);
-        HashSet<CCSPlayerController> coaches = GetAllCoaches();
         HashSet<CCSPlayerController> competitiveSpawnCoaches = new();
         if (spawnsData.Values.Any(list => list.Count == 0)) GetSpawns();
 
@@ -203,12 +204,13 @@ public partial class MatchZy
     {
         if (isPaused || IsTacticalTimeoutActive()) return;
         HashSet<CCSPlayerController> coaches = GetAllCoaches();
+        if (coaches.Count == 0) return;
         string suicidePenalty = GetConvarStringValue(ConVar.Find("mp_suicide_penalty"));
         string deathDropGunEnabled = GetConvarStringValue(ConVar.Find("mp_death_drop_gun"));
         string specFreezeTime = GetConvarStringValue(ConVar.Find("spec_freeze_time"));
         string specFreezeTimeLock = GetConvarStringValue(ConVar.Find("spec_freeze_time_lock"));
         string specFreezeDeathanim = GetConvarStringValue(ConVar.Find("spec_freeze_deathanim_time"));
-        Server.ExecuteCommand("mp_suicide_penalty 0; mp_death_drop_gun 0;spec_freeze_time 0; spec_freeze_time_lock 0; spec_freeze_deathanim_time 0;");
+        Server.ExecuteCommand("mp_suicide_penalty 0;spec_freeze_time 0; spec_freeze_time_lock 0; spec_freeze_deathanim_time 0;");
 
         // Adding timer to make sure above commands are executed successfully.
         AddTimer(0.5f, () =>
@@ -224,7 +226,7 @@ public partial class MatchZy
                 DropWeaponByDesignerName(coach, "weapon_c4");
                 coach.PlayerPawn.Value!.CommitSuicide(explode: false, force: true);
             }
-            Server.ExecuteCommand($"mp_suicide_penalty {suicidePenalty}; mp_death_drop_gun {deathDropGunEnabled}; spec_freeze_time {specFreezeTime}; spec_freeze_time_lock {specFreezeTimeLock}; spec_freeze_deathanim_time {specFreezeDeathanim};");
+            Server.ExecuteCommand($"mp_suicide_penalty {suicidePenalty}; spec_freeze_time {specFreezeTime}; spec_freeze_time_lock {specFreezeTimeLock}; spec_freeze_deathanim_time {specFreezeDeathanim};");
         });
     }
 }

--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -27,6 +27,8 @@ namespace MatchZy
 
         public FakeConVar<bool> stopCommandNoDamage = new("matchzy_stop_command_no_damage", "Whether the stop command becomes unavailable if a player damages a player from the opposing team.", false);
 
+        public FakeConVar<string> matchStartMessage = new("matchzy_match_start_message", "Message to show when the match starts. Use $$$ to break message into multiple lines. Set to \"\" to disable.", "");
+
         [ConsoleCommand("matchzy_whitelist_enabled_default", "Whether Whitelist is enabled by default or not. Default value: false")]
         public void MatchZyWLConvar(CCSPlayerController? player, CommandInfo command)
         {

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -13,7 +13,7 @@ namespace MatchZy
     {
 
         public override string ModuleName => "MatchZy";
-        public override string ModuleVersion => "0.8.4";
+        public override string ModuleVersion => "0.8.5";
 
         public override string ModuleAuthor => "WD- (https://github.com/shobhit-pathak/)";
 

--- a/Utility.cs
+++ b/Utility.cs
@@ -771,7 +771,7 @@ namespace MatchZy
             {
                 Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}MatchZy{ChatColors.Default} Plugin by {ChatColors.Green}WD-{ChatColors.Default}");
             }
-            if (matchStartMessage.Value.Trim() != "")
+            if (matchStartMessage.Value.Trim() != "" && matchStartMessage.Value.Trim() != "\"\"")
             {
                 List<string> matchStartMessages = [.. matchStartMessage.Value.Split("$$$")];
                 foreach (string message in matchStartMessages)
@@ -1037,7 +1037,7 @@ namespace MatchZy
                     long matchId = liveMatchId;
                     int ctTeamNum = reverseTeamSides["CT"] == matchzyTeam1 ? 1 : 2;
                     int tTeamNum = reverseTeamSides["TERRORIST"] == matchzyTeam1 ? 1 : 2;
-                    Winner winner = new(@event.Winner == 3 ? ctTeamNum.ToString() : tTeamNum.ToString(), t1score > t2score ? "team1" : "team2");
+                    Winner winner = new(@event.Winner.ToString(), t1score > t2score ? "team1" : "team2");
 
                     var roundEndEvent = new MatchZyRoundEndedEvent
                     {

--- a/Utility.cs
+++ b/Utility.cs
@@ -771,6 +771,14 @@ namespace MatchZy
             {
                 Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}MatchZy{ChatColors.Default} Plugin by {ChatColors.Green}WD-{ChatColors.Default}");
             }
+            if (matchStartMessage.Value.Trim() != "")
+            {
+                List<string> matchStartMessages = [.. matchStartMessage.Value.Split("$$$")];
+                foreach (string message in matchStartMessages)
+                {
+                    PrintToAllChat(GetColorTreatedString(FormatCvarValue(message.Trim())));
+                }
+            }
         }
 
         public void HandleClanTags()
@@ -1526,8 +1534,9 @@ namespace MatchZy
 
         public void UpdateHostname()
         {
-            if (hostnameFormat.Value.Trim() == "") return;
-            string formattedHostname = FormatCvarValue(hostnameFormat.Value);
+            string hostname = hostnameFormat.Value.Trim();
+            if (hostname == "" || hostname == "\"\"") return;
+            string formattedHostname = FormatCvarValue(hostname);
             Log($"UPDATING HOSTNAME TO: {formattedHostname}");
             Server.ExecuteCommand($"hostname {formattedHostname}");
         }

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -108,3 +108,9 @@ matchzy_hostname_format "MatchZy | {TEAM1} vs {TEAM2}"
 
 // Whether to show damage report after each round or not. Default: true.
 matchzy_enable_damage_report true
+
+// Message to show when the match starts. Use $$$ to break message into multiple lines. Set to "" to disable.
+// Available variables: {TIME}, {MATCH_ID}, {MAP}, {MAPNUMBER}, {TEAM1}, {TEAM2}, {TEAM1_SCORE}, {TEAM2_SCORE}
+// Available Colors: {Default}, {Darkred}, {Green}, {LightYellow}, {LightBlue}, {Olive}, {Lime}, {Red}, {Purple}, {Grey}, {Yellow}, {Gold}, {Silver}, {Blue}, {DarkBlue}
+// Example: {Green} Welcome to the server! {Default} $$$ Agent models are not allowed and may lead to {Red}disqualification!{Default}
+matchzy_match_start_message ""

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -126,6 +126,10 @@ Example: `matchzy_demo_upload_url "https://your-website.com/upload-endpoint"` <b
 ####`matchzy_hostname_format`
 :   The server hostname to use. Set to "" to disable/use existing. Available variables: {TIME}, {MATCH_ID}, {MAP}, {MAPNUMBER}, {TEAM1}, {TEAM2}, {TEAM1_SCORE}, {TEAM2_SCORE}<br>**`Default: MatchZy | {TEAM1} vs {TEAM2}`**
 
+####`matchzy_match_start_message`
+:   Message to show when the match starts. Use $$$ to break message into multiple lines. Set to "" to disable. Available Colors: {Default}, {Darkred}, {Green}, {LightYellow}, {LightBlue}, {Olive}, {Lime}, {Red}, {Purple}, {Grey}, {Yellow}, {Gold}, {Silver}, {Blue}, {DarkBlue}. Example usage: matchzy_match_start_message {Green} Welcome to the server! {Default} $$$ Agent models are not allowed and may lead to {Red}disqualification!{Default}
+<br>**`Default: ""`**
+
 ####`matchzy_loadbackup`
 :   Loads a match backup from the given file. Relative to `csgo/MatchZyDataBackup/`.
 


### PR DESCRIPTION
- Added `matchzy_match_start_message` convar to configure message to show when the match starts. Use $$$ to break message into multiple lines.
- Some improvements and guard checks in coach system
- Fixed `matchzy_hostname_format` not getting disabled on setting its value to ""
- Fixed winner side in `round_end` event