### PR TITLE
Add & Fix a convar

### DIFF
--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -13,6 +13,7 @@ namespace MatchZy
 
         public FakeConVar<bool> smokeColorEnabled = new("matchzy_smoke_color_enabled", "Whether player-specific smoke color is enabled or not. Default: false", false);
         public FakeConVar<bool> techPauseEnabled = new("matchzy_enable_tech_pause", "Whether .tech command is enabled or not. Default: true", true);
+        public FakeConVar<string> techPausePermission  = new("matchzy_tech_pause_flag", "Flag required to use tech pause", "");
         public FakeConVar<int> techPauseDuration  = new("matchzy_tech_pause_duration", "Tech pause duration in seconds. Default value: 300", 300);
 
         public FakeConVar<int> maxTechPausesAllowed  = new("matchzy_max_tech_pauses_allowed", " Max tech pauses allowed. Default value: 2", 2);

--- a/Utility.cs
+++ b/Utility.cs
@@ -1146,6 +1146,19 @@ namespace MatchZy
 
         private void PauseMatch(CCSPlayerController? player, CommandInfo? command)
         {
+            if (!techPauseEnabled.Value && player != null)
+            {
+                PrintToPlayerChat(player, Localizer["matchzy.ready.techpausenotenabled"]);
+                return;
+            }
+            if(!string.IsNullOrEmpty(techPausePermission.Value))
+            {
+                if (!IsPlayerAdmin(player, "css_pause", techPausePermission.Value))
+                {
+                    SendPlayerNotAdminMessage(player);
+                    return;
+                }
+            }
             if (isMatchLive && isPaused)
             {
                 // ReplyToUserCommand(player, "Match is already paused!");

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -39,6 +39,10 @@ matchzy_use_pause_command_for_tactical_pause false
 // Default value: true
 matchzy_enable_tech_pause true
 
+// Flag required to use tech pause. Blank for anyone
+// Default value: ""
+matchzy_tech_pause_flag ""
+
 // Tech pause duration in seconds. Set -1 to keep it infinite.
 // Default value: 300
 matchzy_tech_pause_duration 300


### PR DESCRIPTION
Add a convar to change permission to use pause command & fix `matchzy_use_pause_command_for_tactical_pause` convar not working.