### PR TITLE
[FEATURE] allows .ct or .t after Knife Round

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 obj/*
 bin/*
 /.vs
+MatchZy.sln

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -154,21 +154,15 @@ namespace MatchZy
         public void OnTCommand(CCSPlayerController? player, CommandInfo? command)
         {
             if (player == null || player.UserId == null) return;
-
-            if (isVeto)
-            {
+            if (isVeto) {
                 HandleSideChoice(CsTeam.Terrorist, player.UserId.Value);
                 return;
             }
 
-            if (isSideSelectionPhase && player.TeamNum == knifeWinner)
-            {
-                if (player.Team == CsTeam.Terrorist)
-                {
+            if (isSideSelectionPhase && player.TeamNum == knifeWinner) {
+                if (player.Team == CsTeam.Terrorist) {
                     OnTeamStay(player, command);
-                }
-                else
-                {
+                } else {
                     OnTeamSwitch(player, command);
                 }
             }
@@ -181,20 +175,15 @@ namespace MatchZy
         public void OnCTCommand(CCSPlayerController? player, CommandInfo? command)
         {
             if (player == null || player.UserId == null) return;
-            if (isVeto)
-            {
+            if (isVeto) {
                 HandleSideChoice(CsTeam.CounterTerrorist, player.UserId.Value);
                 return;
             }
 
-            if (isSideSelectionPhase && player.TeamNum == knifeWinner)
-            {
-                if (player.Team == CsTeam.CounterTerrorist)
-                {
+            if (isSideSelectionPhase && player.TeamNum == knifeWinner) {
+                if (player.Team == CsTeam.CounterTerrorist) {
                     OnTeamStay(player, command);
-                }
-                else
-                {
+                } else {
                     OnTeamSwitch(player, command);
                 }
                 return;

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -150,6 +150,60 @@ namespace MatchZy
             }
         }
 
+        [ConsoleCommand("css_t", "Switches team to Terrorist")]
+        public void OnTCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (player == null || player.UserId == null) return;
+
+            if (isVeto)
+            {
+                HandleSideChoice(CsTeam.Terrorist, player.UserId.Value);
+                return;
+            }
+
+            if (isSideSelectionPhase && player.TeamNum == knifeWinner)
+            {
+                if (player.Team == CsTeam.Terrorist)
+                {
+                    OnTeamStay(player, command);
+                }
+                else
+                {
+                    OnTeamSwitch(player, command);
+                }
+            }
+
+            if (!isPractice) return;
+            SideSwitchCommand(player, CsTeam.Terrorist);
+        }
+
+        [ConsoleCommand("css_ct", "Switches team to Counter-Terrorist")]
+        public void OnCTCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (player == null || player.UserId == null) return;
+            if (isVeto)
+            {
+                HandleSideChoice(CsTeam.CounterTerrorist, player.UserId.Value);
+                return;
+            }
+
+            if (isSideSelectionPhase && player.TeamNum == knifeWinner)
+            {
+                if (player.Team == CsTeam.CounterTerrorist)
+                {
+                    OnTeamStay(player, command);
+                }
+                else
+                {
+                    OnTeamSwitch(player, command);
+                }
+                return;
+            }
+
+            if (!isPractice) return;
+            SideSwitchCommand(player, CsTeam.CounterTerrorist);
+        }
+
         [ConsoleCommand("css_tech", "Pause the match")]
         public void OnTechCommand(CCSPlayerController? player, CommandInfo? command)
         {

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -1171,30 +1171,6 @@ namespace MatchZy
             RemoveGrenadeEntities();
         }
 
-        [ConsoleCommand("css_t", "Switches team to Terrorist")]
-        public void OnTCommand(CCSPlayerController? player, CommandInfo? command) {
-            if (player == null || player.UserId == null) return;
-            if (isVeto) {
-                HandleSideChoice(CsTeam.Terrorist, player.UserId.Value);
-                return;
-            }
-            if (!isPractice || player == null) return;
-
-            SideSwitchCommand(player, CsTeam.Terrorist);
-        }
-
-        [ConsoleCommand("css_ct", "Switches team to Counter-Terrorist")]
-        public void OnCTCommand(CCSPlayerController? player, CommandInfo? command) {
-            if (player == null || player.UserId == null) return;
-            if (isVeto) {
-                HandleSideChoice(CsTeam.CounterTerrorist, player.UserId.Value);
-                return;
-            }
-            if (!isPractice) return;
-
-            SideSwitchCommand(player, CsTeam.CounterTerrorist);
-        }
-
         [ConsoleCommand("css_spec", "Switches team to Spectator")]
         public void OnSpecCommand(CCSPlayerController? player, CommandInfo? command) {
             if (!isPractice || player == null) return;

--- a/Utility.cs
+++ b/Utility.cs
@@ -1391,7 +1391,7 @@ namespace MatchZy
             }
             if (isSideSelectionPhase)
             {
-                player!.PrintToChat($" {ChatColors.Green}Side Selection: {ChatColors.Default}.stay, .switch");
+                player!.PrintToChat($" {ChatColors.Green}Side Selection: {ChatColors.Default}.stay, .switch, .ct, .t");
                 return;
             }
             if (matchStarted)


### PR DESCRIPTION
- moves commands `css_t` and `css_ct` from `PracticeMode.cs` to `ConsoleCommands.cs`
- adds .sln to .gitignore
- allows `.t` and `.ct` to be used after knife round for the winner to pick either `.CT` or `.T` based on the old swap/stay commands. 
- adds `.t` and `.ct` to help command for side selection page
- Did not update the `matchzy.knife.sidedecisionpending` to include .ct or .t if there is some more considerations to think of when changing the localization text. 

PR meant to help create some helpful commands