### PR TITLE
Add `.color` command

### DIFF
--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -200,7 +200,8 @@ namespace MatchZy
                 { ".bestctspawn", OnBestCTSpawnCommand },
                 { ".worstctspawn", OnWorstCTSpawnCommand },
                 { ".besttspawn", OnBestTSpawnCommand },
-                { ".worsttspawn", OnWorstTSpawnCommand }
+                { ".worsttspawn", OnWorstTSpawnCommand },
+                { ".color", OnColorCommand }
             };
 
             RegisterEventHandler<EventPlayerConnectFull>(EventPlayerConnectFullHandler);

--- a/PracticeMode.cs
+++ b/PracticeMode.cs
@@ -1756,6 +1756,20 @@ namespace MatchZy
             RemoveSpawnBeams();
         }
 
+        [ConsoleCommand("css_color", "Set cl_color of current player")]
+        public void OnColorCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            if (!IsPlayerValid(player)) return;
+
+            if(command.ArgCount < 2){
+                PrintToPlayerChat(player, $"add number of color, same as cl_color <number>");
+                return;
+            }
+
+            PrintToPlayerChat(player, $"color was: {player.CompTeammateColor}, set to: {command.ArgByIndex(1)}");
+            player.CompTeammateColor = int.Parse(command.ArgByIndex(1));
+        }
+
         public void TeleportPlayerToBestSpawn(CCSPlayerController player, byte teamNum)
         {
             if (!spawnsData.TryGetValue(teamNum, out List<Position>? teamSpawns)) return;


### PR DESCRIPTION
This command usage is the same as cl_color

Can be used in all the modes, to avoid repeated colors on the radar.

I could add an automatization to set the color if it is repeated on the Match Start or Player joined event.