### PR TITLE
Fix decoy air time

### DIFF
--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -336,7 +336,7 @@ public partial class MatchZy
         return HookResult.Continue;
     }
 
-    public HookResult EventDecoyDetonateHandler(EventDecoyDetonate @event, GameEventInfo info)
+    public HookResult EventDecoyDetonateHandler(EventDecoyStarted @event, GameEventInfo info)
     {
         if (!isPractice || isDryRun) return HookResult.Continue;
         CCSPlayerController? player = @event.Userid;

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -535,7 +535,7 @@ namespace MatchZy
             RegisterEventHandler<EventFlashbangDetonate>(EventFlashbangDetonateHandler);
             RegisterEventHandler<EventHegrenadeDetonate>(EventHegrenadeDetonateHandler);
             RegisterEventHandler<EventMolotovDetonate>(EventMolotovDetonateHandler);
-            RegisterEventHandler<EventDecoyDetonate>(EventDecoyDetonateHandler);
+            RegisterEventHandler<EventDecoyStarted>(EventDecoyDetonateHandler);
 
             Console.WriteLine($"[{ModuleName} {ModuleVersion} LOADED] MatchZy by WD- (https://github.com/shobhit-pathak/)");
         }


### PR DESCRIPTION
Switched `EventDecoyDetonate` to `EventDecoyStarted` so it takes the air time once it lands, and not when the decoy finishes