### PR TITLE
Fix: EyeAngels/MoveType and small typo fix

### DIFF
--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -282,7 +282,7 @@ namespace MatchZy
             if (url.Trim() == "") return;
             if (!IsValidUrl(url))
             {
-                Log($"[MatchZyBackupUploadURL] Invalid URL: {url}. Please provide a valid URL for uploading the demo!");
+                Log($"[MatchZyBackupUploadURL] Invalid URL: {url}. Please provide a valid URL for uploading the backup!");
                 return;
             }
             backupUploadURL = url;

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -231,7 +231,8 @@ public partial class MatchZy
                     angle, 
                     velocity, 
                     player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin, 
-                    player.PlayerPawn.Value.EyeAngles,
+                    ((CCSPlayerPawn)player.PlayerPawn.Value).EyeAngles ?? new QAngle(0, 0, 0),
+                    player.PlayerPawn.Value.MoveType,
                     nadeType,
                     DateTime.Now
                 );


### PR DESCRIPTION
Some changes due to CSSharp v1.0.337

EyeAngles was moved to CCSPlayerPawn instead of CCSPlayerPawnBase
Added MoveType

`demo!` was used instead of `backup!` on line 285 by Log for remote_backup_url.