### PR TITLE
Update for cssharp Version 1.0.337

### DIFF
--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -231,8 +231,7 @@ public partial class MatchZy
                     angle, 
                     velocity, 
                     player.PlayerPawn.Value.CBodyComponent!.SceneNode!.AbsOrigin, 
-                    ((CCSPlayerPawn)player.PlayerPawn.Value).EyeAngles ?? new QAngle(0, 0, 0),
-                    player.PlayerPawn.Value.MoveType,
+                    player.PlayerPawn.Value.EyeAngles,
                     nadeType,
                     DateTime.Now
                 );

--- a/MatchZy.csproj
+++ b/MatchZy.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.333">
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.337">
         <PrivateAssets>none</PrivateAssets>
         <ExcludeAssets>runtime</ExcludeAssets>
         <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Updates the csproj version to use version 1.0.337 of cssharp.

This fixes `.throw`, `.last`, the chat messages for the airtime of nades and probably other nade related commands in practice mode.

This also reverts commit 844d2697210f7d23d59d645db31baba9b0554002 as this change is not needed.
While it is correct that `EyeAngles` was moved to `CCSPlayerPawn` from `CCSPlayerPawnBase`, the `player.PlayerPawn.Value` already points at a `CCSPlayerPawn` object and therefore no cast is necessary as well as due to the null checks before no null coalescing operator should be required.
The `MoveType_t` parameter is reverted as well, as it was not used in the `GrenadeThrownData` class and only broke the object creation within this Handler, as no constructor exists for `GrenadeThrownData` that uses a `MoveType_t`
