### PR TITLE
feat: add config option to disable automatic demo recording

### DIFF
--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -125,6 +125,15 @@ namespace MatchZy
             }
         }
 
+        [ConsoleCommand("matchzy_demo_recording_enabled", "Whether to automatically start demo recording when the match goes live. Default value: true")]
+        public void MatchZyDemoRecordingEnabled(CCSPlayerController? player, CommandInfo command)
+        {
+            if (player != null) return;
+            string args = command.ArgString;
+
+            isDemoRecordingEnabled = bool.TryParse(args, out bool isDemoRecordingEnabledValue) ? isDemoRecordingEnabledValue : args != "0" && isDemoRecordingEnabled;
+        }
+
         [ConsoleCommand("get5_demo_upload_url", "If defined, recorded demos will be uploaded to this URL once the map ends.")]
         [ConsoleCommand("matchzy_demo_upload_url", "If defined, recorded demos will be uploaded to this URL once the map ends.")]
         public void MatchZyDemoUploadURL(CCSPlayerController? player, CommandInfo command)

--- a/DemoManagement.cs
+++ b/DemoManagement.cs
@@ -20,9 +20,15 @@ namespace MatchZy
         public string activeDemoFile = "";
 
         public bool isDemoRecording = false;
+        public bool isDemoRecordingEnabled = true;
 
         public void StartDemoRecording()
         {
+            if (!isDemoRecordingEnabled)
+            {
+                Log("[StartDemoRecording] Demo recording is disabled.");
+                return;
+            }
             if (isDemoRecording)
             {
                 Log("[StartDemoRecording] Demo recording is already in progress.");

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -13,6 +13,9 @@ matchzy_knife_enabled_default true
 // Minimum ready players required to start the match. If set to 0, all connected players have to ready-up to start the match. Default: 2
 matchzy_minimum_ready_required 2
 
+// Whether to automatically start demo recording when the match goes live. Default value: true
+matchzy_demo_recording_enabled true
+
 // Path of folder in which demos will be saved. If defined, it must not start with a slash and must end with a slash. Set to empty string to use the csgo root.
 // Example: matchzy_demo_path MatchZy/
 // A folder named MatchZy will be created in csgo folder if it does not exist and will store the recorded demos in it. Default value is MatchZy/ which means demos will be stored in MatchZy/


### PR DESCRIPTION
## Summary
Adds a new configuration option `matchzy_demo_recording_enabled` to control automatic demo recording.

## Description
Currently, MatchZy automatically starts recording demos when a match goes live. This PR adds the ability to disable automatic demo recording through a configuration option.

### Changes:
- Added `matchzy_demo_recording_enabled` config variable (default: `true`)
- Added check in `StartDemoRecording()` to respect the configuration setting
- Updated `config.cfg` with the new configuration option

### Usage:
To disable automatic demo recording, add the following to your `config.cfg`: matchzy_demo_recording_enabled false`

## Testing
- Tested with `matchzy_demo_recording_enabled true` - demos record as normal
- Tested with `matchzy_demo_recording_enabled false` - no demos are recorded
- Verified existing functionality remains unchanged when setting is not specified (defaults to true)

## Motivation
Some server operators may want to disable demo recording to save disk space or because they have their own demo recording solution.