### PR TITLE
Bump CS# version for linux sigs & fixes coach bug

### DIFF
--- a/Coach.cs
+++ b/Coach.cs
@@ -122,7 +122,7 @@ public partial class MatchZy
             // Elevating coach before dropping the C4 to prevent it going inside the ground.
             AddTimer(0.05f, () =>
             {
-                coach!.PlayerPawn.Value!.Teleport(new Vector(coachPosition.PlayerPosition.X, coachPosition.PlayerPosition.Y, coachPosition.PlayerPosition.Z + 20.0f), coachPosition.PlayerAngle, new Vector(0, 0, 0));
+                // coach!.PlayerPawn.Value!.Teleport(new Vector(coachPosition.PlayerPosition.X, coachPosition.PlayerPosition.Y, coachPosition.PlayerPosition.Z + 20.0f), coachPosition.PlayerAngle, new Vector(0, 0, 0));
                 HandleCoachWeapons(coach);
                 coach!.PlayerPawn.Value.Teleport(newPosition.PlayerPosition, newPosition.PlayerAngle, new Vector(0, 0, 0));
             });
@@ -180,7 +180,6 @@ public partial class MatchZy
     private void HandleCoachWeapons(CCSPlayerController coach)
     {
         if (!IsPlayerValid(coach)) return;
-        TransferCoachBomb(coach);
         coach.RemoveWeapons();
     }
 
@@ -194,7 +193,7 @@ public partial class MatchZy
         var bomb = coach.PlayerPawn.Value!.WeaponServices!.MyWeapons
             .Where(w => w != null && w.IsValid && w.Value!.DesignerName == "weapon_c4")
             .FirstOrDefault();
-        if (bomb == null) return; // should never trigger
+        if (bomb == null || bomb.Value == null) return; // should never trigger
 
         var target = Utilities.GetPlayers()
             .FirstOrDefault(
@@ -203,7 +202,7 @@ public partial class MatchZy
                 && p.TeamNum == (int)CsTeam.Terrorist
                 && p.PawnIsAlive
             );
-        if (target == null) return; // should never trigger
+        if (!IsPlayerValid(target)) return; // should never trigger
 
         // transfer bomb
         Log($"[EventPlayerGivenC4 INFO] Transferred bomb from {coach.PlayerName} (Coach) to {target.PlayerName}.");
@@ -267,8 +266,6 @@ public partial class MatchZy
 
             Position coachPosition = new(coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsOrigin, coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsRotation);
             coach!.PlayerPawn.Value!.Teleport(new Vector(coachPosition.PlayerPosition.X, coachPosition.PlayerPosition.Y, coachPosition.PlayerPosition.Z + 20.0f), coachPosition.PlayerAngle, new Vector(0, 0, 0));
-            // Transfer the C4 if it was picked up or passed to the coach.
-            TransferCoachBomb(coach);
             coach.PlayerPawn.Value!.CommitSuicide(explode: false, force: true);
         }
         Server.ExecuteCommand($"mp_suicide_penalty {suicidePenalty}; spec_freeze_time {specFreezeTime}; spec_freeze_time_lock {specFreezeTimeLock}; spec_freeze_deathanim_time {specFreezeDeathanim};");

--- a/Coach.cs
+++ b/Coach.cs
@@ -180,7 +180,7 @@ public partial class MatchZy
     private void HandleCoachWeapons(CCSPlayerController coach)
     {
         if (!IsPlayerValid(coach)) return;
-        DropWeaponByDesignerName(coach, "weapon_c4");
+        // DropWeaponByDesignerName(coach, "weapon_c4");
         coach.RemoveWeapons();
     }
 
@@ -241,7 +241,7 @@ public partial class MatchZy
             Position coachPosition = new(coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsOrigin, coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsRotation);
             coach!.PlayerPawn.Value!.Teleport(new Vector(coachPosition.PlayerPosition.X, coachPosition.PlayerPosition.Y, coachPosition.PlayerPosition.Z + 20.0f), coachPosition.PlayerAngle, new Vector(0, 0, 0));
             // Dropping the C4 if it was picked up or passed to the coach.
-            DropWeaponByDesignerName(coach, "weapon_c4");
+            // DropWeaponByDesignerName(coach, "weapon_c4");
             coach.PlayerPawn.Value!.CommitSuicide(explode: false, force: true);
         }
         Server.ExecuteCommand($"mp_suicide_penalty {suicidePenalty}; spec_freeze_time {specFreezeTime}; spec_freeze_time_lock {specFreezeTimeLock}; spec_freeze_deathanim_time {specFreezeDeathanim};");

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -171,12 +171,9 @@ public partial class MatchZy
 
                 Position coachPosition = new(coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsOrigin, coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsRotation);
                 coach!.PlayerPawn.Value!.Teleport(new Vector(coachPosition.PlayerPosition.X, coachPosition.PlayerPosition.Y, coachPosition.PlayerPosition.Z + 20.0f), coachPosition.PlayerAngle, new Vector(0, 0, 0));
-                // Transfer the C4 if it was picked up or passed to the coach.
-                TransferCoachBomb(coach);
                 AddTimer(1.5f, () =>
                 {
                     coach!.PlayerPawn.Value!.Teleport(new Vector(coachPosition.PlayerPosition.X, coachPosition.PlayerPosition.Y, coachPosition.PlayerPosition.Z + 20.0f), coachPosition.PlayerAngle, new Vector(0, 0, 0));
-                    TransferCoachBomb(coach);
                     CsTeam oldTeam = GetCoachTeam(coach);
                     coach.ChangeTeam(CsTeam.Spectator);
                     AddTimer(0.01f, () => coach.ChangeTeam(oldTeam));

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -171,12 +171,12 @@ public partial class MatchZy
 
                 Position coachPosition = new(coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsOrigin, coach.PlayerPawn.Value!.CBodyComponent!.SceneNode!.AbsRotation);
                 coach!.PlayerPawn.Value!.Teleport(new Vector(coachPosition.PlayerPosition.X, coachPosition.PlayerPosition.Y, coachPosition.PlayerPosition.Z + 20.0f), coachPosition.PlayerAngle, new Vector(0, 0, 0));
-                // Dropping the C4 if it was picked up or passed to the coach.
-                // DropWeaponByDesignerName(coach, "weapon_c4");
+                // Transfer the C4 if it was picked up or passed to the coach.
+                TransferCoachBomb(coach);
                 AddTimer(1.5f, () =>
                 {
                     coach!.PlayerPawn.Value!.Teleport(new Vector(coachPosition.PlayerPosition.X, coachPosition.PlayerPosition.Y, coachPosition.PlayerPosition.Z + 20.0f), coachPosition.PlayerAngle, new Vector(0, 0, 0));
-                    // DropWeaponByDesignerName(coach, "weapon_c4");
+                    TransferCoachBomb(coach);
                     CsTeam oldTeam = GetCoachTeam(coach);
                     coach.ChangeTeam(CsTeam.Spectator);
                     AddTimer(0.01f, () => coach.ChangeTeam(oldTeam));
@@ -200,21 +200,7 @@ public partial class MatchZy
             // check if coach
             var coaches = reverseTeamSides["TERRORIST"].coach;
             if (coaches.Contains(recv)) {
-                // find bomb and new target
-                var bomb = recv.PlayerPawn.Value!.WeaponServices!.MyWeapons
-                    .Where(w => w != null && w.IsValid && w.Value!.DesignerName == "weapon_c4")
-                    .FirstOrDefault();
-                var target = Utilities.GetPlayers()
-                    .FirstOrDefault(p => p != null && p != recv && IsPlayerValid(p)
-                        && p.TeamNum == (int)CsTeam.Terrorist && p.PawnIsAlive);
-
-                if (bomb == null) return HookResult.Continue; // should never trigger
-                if (target == null) return HookResult.Continue; // should never trigger
-
-                // transfer bomb
-                Log($"[EventPlayerGivenC4 INFO] Transferred bomb from {recv.PlayerName} (Coach) to {target.PlayerName}.");
-                bomb.Value!.Remove();
-                target.GiveNamedItem("weapon_c4");
+                TransferCoachBomb(recv);
             }
         } catch (Exception e) {
             Log($"[EventPlayerGivenC4 FATAL] An error occured: {e.Message}");
@@ -305,7 +291,6 @@ public partial class MatchZy
                     info.DontBroadcast = true;
                 }
             }
-    
             return HookResult.Continue;
         }
         catch (Exception e)
@@ -353,7 +338,6 @@ public partial class MatchZy
         }
         return HookResult.Continue;
     }
-
 
     public HookResult EventMolotovDetonateHandler(EventMolotovDetonate @event, GameEventInfo info)
     {

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -208,6 +208,7 @@ namespace MatchZy
             RegisterEventHandler<EventCsWinPanelMatch>(EventCsWinPanelMatchHandler);
             RegisterEventHandler<EventRoundStart>(EventRoundStartHandler);
             RegisterEventHandler<EventRoundFreezeEnd>(EventRoundFreezeEndHandler);
+            RegisterEventHandler<EventPlayerGivenC4>(EventPlayerGivenC4);
             RegisterEventHandler<EventPlayerDeath>(EventPlayerDeathPreHandler, hookMode: HookMode.Pre);
             RegisterListener<Listeners.OnClientDisconnectPost>(playerSlot => { 
                // May not be required, but just to be on safe side so that player data is properly updated in dictionaries

--- a/MatchZy.csproj
+++ b/MatchZy.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.337">
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.338">
         <PrivateAssets>none</PrivateAssets>
         <ExcludeAssets>runtime</ExcludeAssets>
         <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This pull request fixes #322, fixes #319, and the CommitSuicide issue due to old linux sigs (fixes #329).

Instead of dropping the bomb, we listen for the GivenC4 event and do a bomb transfer (remove bomb from coach and give new one to a non-coach teammate). This has the benefit that the bomb will not get stuck out of bounds and there does not have to be any consideration as to if the coach obtains the bomb (i.e. because someone dropped it to him).

The bump to v1.0.338 of counterstrikesharp is necessary to prevent server crash on the CommitSuicide call when the coach is playing on Linux (because of changed signatures for CommitSuicide).

I am quite new to C# in general so I hope the code is fine structure-wise. Logically it should cover all cases where one of the coaches obtains the bomb in some way.