### PR TITLE
Fix player table creation script

### DIFF
--- a/DatabaseStats.cs
+++ b/DatabaseStats.cs
@@ -224,8 +224,8 @@ namespace MatchZy
                 cash_earned INT NOT NULL,
                 enemies_flashed INT NOT NULL,
                 PRIMARY KEY (matchid, mapnumber, steamid64),
-                FOREIGN KEY (matchid) REFERENCES matchzy_stats_matches (matchid),
-                FOREIGN KEY (mapnumber) REFERENCES matchzy_stats_maps (mapnumber)
+                CONSTRAINT fk_player_map_ref FOREIGN KEY (matchid, mapnumber) 
+                    REFERENCES matchzy_stats_maps (matchid, mapnumber)
             )");
         }
 


### PR DESCRIPTION
### Description

This PR resolves a database schema creation error that occurred during server startup with MySQL when trying to define a foreign key constraints on the `matchzy_stats_players` table.

The schema creation failed with the error:

>Database connection or table creation error: Failed to add the foreign key constraint. Missing unique key for constraint 'matchzy_stats_players_ibfk_2' in the referenced table 'matchzy_stats_maps'

This happened because the `matchzy_stats_players` table attempted to define a foreign key relationship to the `matchzy_stats_maps` table using only the `mapnumber` column:

```SQL
-- Original (Incorrect) Foreign Key
FOREIGN KEY (mapnumber) REFERENCES matchzy_stats_maps (mapnumber)
```

However, the primary key of the `matchzy_stats_maps` table is a composite key using both `matchid` and `mapnumber` (`PRIMARY KEY (matchid, mapnumber)`). Since a FK must reference a PK or a Unique Key in the target table, referencing only `mapnumber` failed, as it is not unique on its own.

### Changes

The foreign key definition in the `matchzy_stats_players` table was fixed by replacing the two original, single-column FK definitions with one composite FK that correctly references the primary key of the `matchzy_stats_maps` table:

```sql
-- Corrected Composite Foreign Key
CONSTRAINT fk_player_map_ref FOREIGN KEY (matchid, mapnumber) REFERENCES matchzy_stats_maps (matchid, mapnumber)
```