### PR TITLE
[Important Fix] remove /noclip command. 

### DIFF
--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -717,6 +717,10 @@ namespace MatchZy
         public HookResult OnConsoleNoClip(CCSPlayerController? player, CommandInfo cmd) {
             if (player == null || !player.PawnIsAlive || player.Team == CsTeam.Spectator || player.Team == CsTeam.None)
                 return HookResult.Stop;
+            if (cmd.CallingContext != CommandCallingContext.Console) {
+                return HookResult.Stop; // abort when called in chat.
+                                        // inefficient but CS# forces both...
+            }
 
             // inspired by cs2-noclip
             if (player.PlayerPawn.Value!.MoveType == MoveType_t.MOVETYPE_NOCLIP) {


### PR DESCRIPTION
## Problem Statement
In #341 I seem to have mistakenly introduced the /noclip command that has NO PERMISSION CHECKS. I did not know creating a command listener using AddCommandListener had the side effect of creating a chat command as well.

## Side Rant
This behaviour, to my knowledge, is documented nowhere and is highly unintuitive. Why would creating a listener CREATE a command? Let alone a chat command? If you ask me that is insane, but who am I to judge. This slipped through my testing because who in the right mind would test for chat commands after adding a - what I can tell from the documentation - listener to an existing console command. Especially seeing that there is also AddCommand. Imho this is an API disaster, especially with such sparse documentation.

## The "Fix"
I fixed the problem by checking the `CommandCallingContext` and only allow `Console`. This ensures the correct behaviour stated in #341 and keeps compatability with cs2-noclip (as we don't overwrite the command anymore; whoops).

## Why is this so important?
This fix is needed asap. The `/noclip` chat command does not check for any state/permissions as it relies solely on the `sv_cheats` check performed on the `noclip` console command by the server. This was intentional, because `noclip` binds are often used in quick succession and it makes no sense to waste time on useless checks that are performed on console commands anyway. Anyhow, this means `/noclip` can be used ANYTIME, INCLUDING IN MATCHES!! This is a huge risk to competitive integrity. I do not see this being such a big issue as to tag shobhit but I would appreciate a quick rollout.

## Why a new PR?
Tbh never worked that much with github and I have no idea how or even if it is possible when the PR is already closed and merged, I hope this is fine.

## Special Thanks
Thank you to @mrc4tt and @ShiNxz (on discord) for bringing this to my attention so quickly. The fix is robust now, no more command shenanigans.