### PR TITLE
feat: send player_death event to G5API (v0.8.20)

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -33,14 +33,14 @@ jobs:
         run: |
           CSSHARP_VERSION=$(grep -Po '<PackageReference Include="CounterStrikeSharp.API" Version="\K\d+(\.\d+)*' MatchZy.csproj)
           MATCHZY_VERSION=${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
-          echo "Creating MatchZy base package with version: $MATCHZY_VERSION"
-          dotnet publish -o package/addons/counterstrikesharp/plugins/MatchZy
-          cp -r cfg package
-          cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION.zip * && cd ..
 
-          echo "Creating package with CounterStrikeSharp (CSSharp) v$CSSHARP_VERSION for Linux"
-          cd package/
-          [ -e addons/counterstrikesharp ] && rm -rf addons/counterstrikesharp
+          echo "Building base package (v$MATCHZY_VERSION)"
+          dotnet publish -o pkg-base/addons/counterstrikesharp/plugins/MatchZy
+          cp -r cfg pkg-base/
+
+          echo "Building Linux package with CSSharp v$CSSHARP_VERSION"
+          cp -r pkg-base/. pkg-linux/
+          cd pkg-linux/
           curl -s https://api.github.com/repos/roflmuffin/CounterStrikeSharp/releases/tags/v$CSSHARP_VERSION |
               grep "/counterstrikesharp-with-runtime-linux-$CSSHARP_VERSION" |
               cut -d : -f 2,3 |
@@ -50,17 +50,11 @@ jobs:
           unzip -o cssharp-linux.zip -d .
           rm cssharp-linux.zip
           cd ../
+          dotnet publish -o pkg-linux/addons/counterstrikesharp/plugins/MatchZy
 
-          dotnet publish -o package/addons/counterstrikesharp/plugins/MatchZy
-
-          cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION-with-cssharp-linux.zip * && cd ..
-
-          rm -r package/*
-
-          echo "Creating package with CounterStrikeSharp (CSSharp) v$CSSHARP_VERSION for Windows"
-          cp -r cfg package
-          cd package/
-          [ -e addons/counterstrikesharp ] && rm -rf addons/counterstrikesharp
+          echo "Building Windows package with CSSharp v$CSSHARP_VERSION"
+          cp -r pkg-base/. pkg-windows/
+          cd pkg-windows/
           curl -s https://api.github.com/repos/roflmuffin/CounterStrikeSharp/releases/tags/v$CSSHARP_VERSION |
               grep "/counterstrikesharp-with-runtime-windows-$CSSHARP_VERSION" |
               cut -d : -f 2,3 |
@@ -70,28 +64,25 @@ jobs:
           unzip -o cssharp-windows.zip -d .
           rm cssharp-windows.zip
           cd ../
-
-          dotnet publish -o package/addons/counterstrikesharp/plugins/MatchZy
-
-          cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION-with-cssharp-windows.zip * && cd ..
+          dotnet publish -o pkg-windows/addons/counterstrikesharp/plugins/MatchZy
 
       - name: Upload MatchZy base
         uses: actions/upload-artifact@v4
         with:
           name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
-          path: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
+          path: pkg-base/
           retention-days: 14
 
       - name: Upload MatchZy with CSSharp (Linux)
         uses: actions/upload-artifact@v4
         with:
           name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux
-          path: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
+          path: pkg-linux/
           retention-days: 14
 
       - name: Upload MatchZy with CSSharp (Windows)
         uses: actions/upload-artifact@v4
         with:
           name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows
-          path: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip
+          path: pkg-windows/
           retention-days: 14

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,0 +1,86 @@
+name: Build (dev)
+
+on:
+  push:
+    paths-ignore:
+        - "documentation/**"
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  build:
+    permissions:
+        contents: read
+    name: Build (dev)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0'
+
+      - name: Get MatchZy Version
+        id: MATCHZY_VERSION
+        run: |
+            MATCHZY_VERSION=$(grep -oP 'ModuleVersion\s*=>\s*"\K[^"]*' MatchZy.cs)
+            echo "MATCHZY_VERSION=$MATCHZY_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Build Artifacts
+        run: |
+          CSSHARP_VERSION=$(grep -Po '<PackageReference Include="CounterStrikeSharp.API" Version="\K\d+(\.\d+)*' MatchZy.csproj)
+          MATCHZY_VERSION=${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
+          echo "Creating MatchZy base package with version: $MATCHZY_VERSION"
+          dotnet publish -o package/addons/counterstrikesharp/plugins/MatchZy
+          cp -r cfg package
+          cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION.zip * && cd ..
+
+          echo "Creating package with CounterStrikeSharp (CSSharp) v$CSSHARP_VERSION for Linux"
+          cd package/
+          [ -e addons/counterstrikesharp ] && rm -rf addons/counterstrikesharp
+          curl -s https://api.github.com/repos/roflmuffin/CounterStrikeSharp/releases/tags/v$CSSHARP_VERSION |
+              grep "/counterstrikesharp-with-runtime-linux-$CSSHARP_VERSION" |
+              cut -d : -f 2,3 |
+              tr -d \" |
+              head -n 1 |
+              wget -O cssharp-linux.zip -qi -
+          unzip -o cssharp-linux.zip -d .
+          rm cssharp-linux.zip
+          cd ../
+
+          dotnet publish -o package/addons/counterstrikesharp/plugins/MatchZy
+
+          cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION-with-cssharp-linux.zip * && cd ..
+
+          rm -r package/*
+
+          echo "Creating package with CounterStrikeSharp (CSSharp) v$CSSHARP_VERSION for Windows"
+          cp -r cfg package
+          cd package/
+          [ -e addons/counterstrikesharp ] && rm -rf addons/counterstrikesharp
+          curl -s https://api.github.com/repos/roflmuffin/CounterStrikeSharp/releases/tags/v$CSSHARP_VERSION |
+              grep "/counterstrikesharp-with-runtime-windows-$CSSHARP_VERSION" |
+              cut -d : -f 2,3 |
+              tr -d \" |
+              head -n 1 |
+              wget -O cssharp-windows.zip -qi -
+          unzip -o cssharp-windows.zip -d .
+          rm cssharp-windows.zip
+          cd ../
+
+          dotnet publish -o package/addons/counterstrikesharp/plugins/MatchZy
+
+          cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION-with-cssharp-windows.zip * && cd ..
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-dev
+          path: |
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip
+          retention-days: 14

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -75,12 +75,23 @@ jobs:
 
           cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION-with-cssharp-windows.zip * && cd ..
 
-      - name: Upload Build Artifacts
+      - name: Upload MatchZy base
         uses: actions/upload-artifact@v4
         with:
-          name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-dev
-          path: |
-            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
-            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
-            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip
+          name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
+          path: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
+          retention-days: 14
+
+      - name: Upload MatchZy with CSSharp (Linux)
+        uses: actions/upload-artifact@v4
+        with:
+          name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux
+          path: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
+          retention-days: 14
+
+      - name: Upload MatchZy with CSSharp (Windows)
+        uses: actions/upload-artifact@v4
+        with:
+          name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows
+          path: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,10 +101,3 @@ jobs:
             MatchZy-${{ env.MATCHZY_VERSION }}.zip
             MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-linux.zip
             MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-windows.zip
-
-      - name: Publish Discord Notification
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        uses: Ilshidur/action-discord@0.3.2
-        with:
-          args: "A new release of MatchZy is here! MatchZy v${{ env.MATCHZY_VERSION }} (${{ steps.create_release.outputs.url }})"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
         - "documentation/**"
     branches:
       - main
+      - dev
   workflow_dispatch:
 
 jobs:
@@ -30,14 +31,15 @@ jobs:
         run: |
             MATCHZY_VERSION=$(grep -oP 'ModuleVersion\s*=>\s*"\K[^"]*' MatchZy.cs)
             echo "MATCHZY_VERSION=$MATCHZY_VERSION" >> $GITHUB_ENV
-      - name: Build and Release Artifacts
+            echo "MATCHZY_VERSION=$MATCHZY_VERSION" >> $GITHUB_OUTPUT
+      - name: Build Artifacts
         run: |
           CSSHARP_VERSION=$(grep -Po '<PackageReference Include="CounterStrikeSharp.API" Version="\K\d+(\.\d+)*' MatchZy.csproj)
           echo "Creating MatchZy base package with version: $MATCHZY_VERSION"
           dotnet publish -o package/addons/counterstrikesharp/plugins/MatchZy
-          cp -r cfg package 
+          cp -r cfg package
           cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION.zip * && cd ..
-    
+
           echo "Creating package with CounterStrikeSharp (CSSharp) v$CSSHARP_VERSION for Linux"
           cd package/
           echo "Installing CounterStrikeSharp (CSSharp) v$CSSHARP_VERSION"
@@ -77,34 +79,40 @@ jobs:
 
           cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION-with-cssharp-windows.zip * && cd ..
 
+      # dev branch: upload artifacts only (no release)
+      - name: Upload Build Artifacts (dev)
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/upload-artifact@v4
+        with:
+          name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-dev
+          path: |
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip
+          retention-days: 14
+
+      # main branch: create a GitHub release
       - name: Create Release
-        id: create_release
+        if: github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: MatchZy ${{ env.MATCHZY_VERSION }}
-          tag_name: ${{ env.MATCHZY_VERSION }}
+          name: MatchZy ${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
+          tag_name: ${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
           body: |
-            Please see the [`CHANGELOG.md`](https://github.com/shobhit-pathak/MatchZy/blob/main/CHANGELOG.md) for details on changes.
+            Please see the [`CHANGELOG.md`](https://github.com/French-CSGO/MatchZy/blob/main/CHANGELOG.md) for details on changes.
 
             Installation:
             There are 3 files attached here:
-            One is the MatchZy-${{ env.MATCHZY_VERSION }}.zip which only contains the MatchZy plugin files. Extract its contents in csgo/ directory of the server. (Prerequisite: Metamod and CounterStrikeSharp should be already installed on the server)
-            
-            Second one is MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-linux.zip which contains MatchZy plugin file as well as CounterStrikeSharp files (for linux) so that you don't have to install CounterStrikeSharp separately. Simply extract its contents in csgo/ directory of the server. 
-            Third one is MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-windows.zip which is same as above, but for Windows.
+            One is the MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip which only contains the MatchZy plugin files. Extract its contents in csgo/ directory of the server. (Prerequisite: Metamod and CounterStrikeSharp should be already installed on the server)
+
+            Second one is MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip which contains MatchZy plugin file as well as CounterStrikeSharp files (for linux) so that you don't have to install CounterStrikeSharp separately. Simply extract its contents in csgo/ directory of the server.
+            Third one is MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip which is same as above, but for Windows.
             (Prerequisite: Metamod should be already installed on the server, rest CounterStrikeSharp and MatchZy will be installed once you extract the contents) (WITH CSSHARP RELEASE IS RECOMMENDED FOR FIRST TIME INSTALLERS)
           draft: false
           prerelease: false
           files: |
-            MatchZy-${{ env.MATCHZY_VERSION }}.zip
-            MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-linux.zip
-            MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-windows.zip
-
-      - name: Publish Discord Notification
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        uses: Ilshidur/action-discord@0.3.2
-        with:
-          args: "A new release of MatchZy is here! MatchZy v${{ env.MATCHZY_VERSION }} (${{ steps.create_release.outputs.url }})"
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
         - "documentation/**"
     branches:
       - main
-      - dev
   workflow_dispatch:
 
 jobs:
@@ -31,8 +30,7 @@ jobs:
         run: |
             MATCHZY_VERSION=$(grep -oP 'ModuleVersion\s*=>\s*"\K[^"]*' MatchZy.cs)
             echo "MATCHZY_VERSION=$MATCHZY_VERSION" >> $GITHUB_ENV
-            echo "MATCHZY_VERSION=$MATCHZY_VERSION" >> $GITHUB_OUTPUT
-      - name: Build Artifacts
+      - name: Build and Release Artifacts
         run: |
           CSSHARP_VERSION=$(grep -Po '<PackageReference Include="CounterStrikeSharp.API" Version="\K\d+(\.\d+)*' MatchZy.csproj)
           echo "Creating MatchZy base package with version: $MATCHZY_VERSION"
@@ -79,40 +77,27 @@ jobs:
 
           cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION-with-cssharp-windows.zip * && cd ..
 
-      # dev branch: upload artifacts only (no release)
-      - name: Upload Build Artifacts (dev)
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/upload-artifact@v4
-        with:
-          name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-dev
-          path: |
-            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
-            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
-            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip
-          retention-days: 14
-
-      # main branch: create a GitHub release
       - name: Create Release
-        if: github.ref == 'refs/heads/main'
+        id: create_release
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: MatchZy ${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
-          tag_name: ${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
+          name: MatchZy ${{ env.MATCHZY_VERSION }}
+          tag_name: ${{ env.MATCHZY_VERSION }}
           body: |
             Please see the [`CHANGELOG.md`](https://github.com/French-CSGO/MatchZy/blob/main/CHANGELOG.md) for details on changes.
 
             Installation:
             There are 3 files attached here:
-            One is the MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip which only contains the MatchZy plugin files. Extract its contents in csgo/ directory of the server. (Prerequisite: Metamod and CounterStrikeSharp should be already installed on the server)
+            One is the MatchZy-${{ env.MATCHZY_VERSION }}.zip which only contains the MatchZy plugin files. Extract its contents in csgo/ directory of the server. (Prerequisite: Metamod and CounterStrikeSharp should be already installed on the server)
 
-            Second one is MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip which contains MatchZy plugin file as well as CounterStrikeSharp files (for linux) so that you don't have to install CounterStrikeSharp separately. Simply extract its contents in csgo/ directory of the server.
-            Third one is MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip which is same as above, but for Windows.
+            Second one is MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-linux.zip which contains MatchZy plugin file as well as CounterStrikeSharp files (for linux) so that you don't have to install CounterStrikeSharp separately. Simply extract its contents in csgo/ directory of the server.
+            Third one is MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-windows.zip which is same as above, but for Windows.
             (Prerequisite: Metamod should be already installed on the server, rest CounterStrikeSharp and MatchZy will be installed once you extract the contents) (WITH CSSHARP RELEASE IS RECOMMENDED FOR FIRST TIME INSTALLERS)
           draft: false
           prerelease: false
           files: |
-            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
-            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
-            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip
+            MatchZy-${{ env.MATCHZY_VERSION }}.zip
+            MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-linux.zip
+            MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-windows.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build (dev)
+name: Build and Release
 
 on:
   push:
@@ -6,13 +6,14 @@ on:
         - "documentation/**"
     branches:
       - main
+      - dev
   workflow_dispatch:
 
 jobs:
   build:
     permissions:
-        contents: read
-    name: Build (dev)
+        contents: write
+    name: Build and Release
     runs-on: ubuntu-latest
     outputs:
         MATCHZY_VERSION: ${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
@@ -31,14 +32,14 @@ jobs:
             MATCHZY_VERSION=$(grep -oP 'ModuleVersion\s*=>\s*"\K[^"]*' MatchZy.cs)
             echo "MATCHZY_VERSION=$MATCHZY_VERSION" >> $GITHUB_ENV
             echo "MATCHZY_VERSION=$MATCHZY_VERSION" >> $GITHUB_OUTPUT
-      - name: Build and Release Artifacts
+      - name: Build Artifacts
         run: |
           CSSHARP_VERSION=$(grep -Po '<PackageReference Include="CounterStrikeSharp.API" Version="\K\d+(\.\d+)*' MatchZy.csproj)
           echo "Creating MatchZy base package with version: $MATCHZY_VERSION"
           dotnet publish -o package/addons/counterstrikesharp/plugins/MatchZy
-          cp -r cfg package 
+          cp -r cfg package
           cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION.zip * && cd ..
-    
+
           echo "Creating package with CounterStrikeSharp (CSSharp) v$CSSHARP_VERSION for Linux"
           cd package/
           echo "Installing CounterStrikeSharp (CSSharp) v$CSSHARP_VERSION"
@@ -78,7 +79,9 @@ jobs:
 
           cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION-with-cssharp-windows.zip * && cd ..
 
-      - name: Upload Build Artifacts
+      # dev branch: upload artifacts only (no release)
+      - name: Upload Build Artifacts (dev)
+        if: github.ref == 'refs/heads/dev'
         uses: actions/upload-artifact@v4
         with:
           name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-dev
@@ -87,3 +90,29 @@ jobs:
             MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
             MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip
           retention-days: 14
+
+      # main branch: create a GitHub release
+      - name: Create Release
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: MatchZy ${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
+          tag_name: ${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
+          body: |
+            Please see the [`CHANGELOG.md`](https://github.com/French-CSGO/MatchZy/blob/main/CHANGELOG.md) for details on changes.
+
+            Installation:
+            There are 3 files attached here:
+            One is the MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip which only contains the MatchZy plugin files. Extract its contents in csgo/ directory of the server. (Prerequisite: Metamod and CounterStrikeSharp should be already installed on the server)
+
+            Second one is MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip which contains MatchZy plugin file as well as CounterStrikeSharp files (for linux) so that you don't have to install CounterStrikeSharp separately. Simply extract its contents in csgo/ directory of the server.
+            Third one is MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip which is same as above, but for Windows.
+            (Prerequisite: Metamod should be already installed on the server, rest CounterStrikeSharp and MatchZy will be installed once you extract the contents) (WITH CSSHARP RELEASE IS RECOMMENDED FOR FIRST TIME INSTALLERS)
+          draft: false
+          prerelease: false
+          files: |
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Release
+name: Build (dev)
 
 on:
   push:
@@ -11,8 +11,8 @@ on:
 jobs:
   build:
     permissions:
-        contents: write
-    name: Build and Release
+        contents: read
+    name: Build (dev)
     runs-on: ubuntu-latest
     outputs:
         MATCHZY_VERSION: ${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}
@@ -30,6 +30,7 @@ jobs:
         run: |
             MATCHZY_VERSION=$(grep -oP 'ModuleVersion\s*=>\s*"\K[^"]*' MatchZy.cs)
             echo "MATCHZY_VERSION=$MATCHZY_VERSION" >> $GITHUB_ENV
+            echo "MATCHZY_VERSION=$MATCHZY_VERSION" >> $GITHUB_OUTPUT
       - name: Build and Release Artifacts
         run: |
           CSSHARP_VERSION=$(grep -Po '<PackageReference Include="CounterStrikeSharp.API" Version="\K\d+(\.\d+)*' MatchZy.csproj)
@@ -77,27 +78,12 @@ jobs:
 
           cd package && zip -q -r ../MatchZy-$MATCHZY_VERSION-with-cssharp-windows.zip * && cd ..
 
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: MatchZy ${{ env.MATCHZY_VERSION }}
-          tag_name: ${{ env.MATCHZY_VERSION }}
-          body: |
-            Please see the [`CHANGELOG.md`](https://github.com/shobhit-pathak/MatchZy/blob/main/CHANGELOG.md) for details on changes.
-
-            Installation:
-            There are 3 files attached here:
-            One is the MatchZy-${{ env.MATCHZY_VERSION }}.zip which only contains the MatchZy plugin files. Extract its contents in csgo/ directory of the server. (Prerequisite: Metamod and CounterStrikeSharp should be already installed on the server)
-            
-            Second one is MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-linux.zip which contains MatchZy plugin file as well as CounterStrikeSharp files (for linux) so that you don't have to install CounterStrikeSharp separately. Simply extract its contents in csgo/ directory of the server. 
-            Third one is MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-windows.zip which is same as above, but for Windows.
-            (Prerequisite: Metamod should be already installed on the server, rest CounterStrikeSharp and MatchZy will be installed once you extract the contents) (WITH CSSHARP RELEASE IS RECOMMENDED FOR FIRST TIME INSTALLERS)
-          draft: false
-          prerelease: false
-          files: |
-            MatchZy-${{ env.MATCHZY_VERSION }}.zip
-            MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-linux.zip
-            MatchZy-${{ env.MATCHZY_VERSION }}-with-cssharp-windows.zip
+          name: MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-dev
+          path: |
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-linux.zip
+            MatchZy-${{ steps.MATCHZY_VERSION.outputs.MATCHZY_VERSION }}-with-cssharp-windows.zip
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache

--- a/BackupManagement.cs
+++ b/BackupManagement.cs
@@ -172,7 +172,11 @@ namespace MatchZy
             
             if (!input.Contains('\\') && !input.Contains('/'))
             {
-                // If no directory separators are found, return the input as-is
+                // No path separators — extract up to the end of ".json" in case
+                // the caller passed a full info line (e.g. from get5_listbackups).
+                int jsonIdx = input.IndexOf(".json", StringComparison.OrdinalIgnoreCase);
+                if (jsonIdx != -1)
+                    return input.Substring(0, jsonIdx + 5);
                 return input;
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # MatchZy Changelog
 
+# 0.8.19
+
+#### March 19, 2026
+
+- Added new per-player statistics tracked and stored in the database: `bomb_plants`, `bomb_defuses`, `knife_kills`, `friendlies_flashed`, `teamkill`, `suicide`, `first_kill_t`, `first_kill_ct`, `first_death_t`, `first_death_ct`.
+- These statistics are also included in G5 API event payloads (`PlayerStats` instance).
+
 # 0.8.15
 
 #### October 26, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MatchZy Changelog
 
+# 0.8.20
+
+#### March 20, 2026
+
+- Added `player_death` event sent to G5 API on each kill during a live match. The event includes victim, attacker, assister, weapon, headshot, thru-smoke, penetrated, attacker-blind, no-scope, suicide, friendly fire, and flash assist data — stored in `player_stat_extras` on the API side.
+
 # 0.8.19
 
 #### March 19, 2026

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+# MatchZy — Claude Instructions
+
+## Vue d'ensemble
+
+Plugin CS2 (Counter-Strike 2) pour la gestion de matchs compétitifs.
+Écrit en C# sur CounterStrikeSharp API (.NET 8.0).
+Fork French-CSGO — version 0.8.18+.
+
+## Stack technique
+
+- **Langage** : C# (.NET 8.0, nullable enabled, implicit usings)
+- **Framework plugin** : CounterStrikeSharp.API v1.0.342
+- **ORM** : Dapper v2.1.15
+- **BDD** : SQLite (défaut) via Microsoft.Data.Sqlite + MySqlConnector (optionnel)
+- **Sérialisation** : Newtonsoft.Json v13
+- **CSV** : CsvHelper v30
+
+## Build
+
+```bash
+dotnet publish -o package/addons/counterstrikesharp/plugins/MatchZy
+```
+
+Le CI/CD GitHub Actions produit 3 archives :
+- `MatchZy-VERSION.zip` — plugin seul (CounterStrikeSharp requis séparément)
+- `MatchZy-VERSION-with-cssharp-linux.zip`
+- `MatchZy-VERSION-with-cssharp-windows.zip`
+
+## Structure du projet
+
+```
+matchzy/
+  MatchZy.cs                   # Classe principale du plugin, routing des commandes, état joueurs
+  MatchManagement.cs           # Chargement config match, équipes, transitions d'état
+  ConsoleCommands.cs           # Commandes console admin et joueur
+  EventHandlers.cs             # Handlers des événements CS2 (round, bombe, joueurs)
+  Utility.cs                   # Fonctions utilitaires, formatage (~95 KB)
+  PracticeMode.cs              # Mode pratique : spawns, bots, grenades (~93 KB)
+  DatabaseStats.cs             # Stats SQLite/MySQL (matchs, maps, joueurs)
+  MapVeto.cs                   # Système de veto/ban de maps (BO1/BO3/BO5)
+  BackupManagement.cs          # Backup/restauration de rounds (système Valve)
+  Pausing.cs                   # Pause/unpause, pauses tactiques, vote d'équipe
+  ReadySystem.cs               # Système de ready-up des joueurs
+  DemoManagement.cs            # Enregistrement et upload des démos
+  G5API.cs                     # Intégration Get5 Panel API (publication d'événements)
+  Teams.cs                     # Gestion des équipes, swaps, verrouillage
+  Coach.cs                     # Système de coaching, spawns fixes par map
+  ConfigConvars.cs             # Variables de configuration (cvars)
+  Events.cs                    # Classes d'événements sérialisables (webhooks/API)
+  PlayerStatsTracking.cs       # Stats joueurs par round (K/D, damage, KAST, bombe)
+  DamageInfo.cs                # Suivi des dégâts pour les rapports de round
+  Constants.cs                 # Mappings types de grenades
+  MatchZy.csproj               # Fichier projet .NET
+  cfg/MatchZy/
+    config.cfg                  # Configuration principale du plugin
+    database.json               # Connexion BDD (SQLite par défaut, MySQL optionnel)
+    admins.json                 # Définition des admins et leurs permissions
+    knife.cfg                   # Config phase couteau
+    warmup.cfg                  # Config warmup
+    live.cfg                    # Config match live
+    prac.cfg                    # Config mode pratique
+    whitelist.cfg               # Whitelist joueurs
+  lang/
+    en.json, fr.json, de.json   # Localisation (12 langues)
+    es-ES.json, pt-BR.json, ru.json, ja.json, hu.json, uz.json
+    zh-Hans.json, zh-Hant.json
+  spawns/coach/                 # Positions spawn coach par map (JSON)
+    de_ancient.json, de_anubis.json, de_dust2.json, de_inferno.json, de_mirage.json
+```
+
+## Cycle de vie d'un match
+
+1. **Warmup** — joueurs rejoignent, se configurent, se ready
+2. **Round couteau** (optionnel) — détermine l'assignation des côtés
+3. **Sélection des côtés** — si configuré
+4. **Série de maps** — veto + jeu (BO1/BO3/BO5)
+5. **Upload démo** — automatique après fin de map
+6. **Stats sauvegardées** — BDD + export CSV
+
+## Schéma de base de données
+
+| Table | Contenu |
+|-------|---------|
+| `matchzy_stats_matches` | Métadonnées match (noms équipes, scores, type série) |
+| `matchzy_stats_maps` | Résultats par map |
+| `matchzy_stats_players` | Stats par joueur et par round (K/D, damage, utility damage…) |
+
+## Événements publiés (Get5 API / Webhooks)
+
+Définis dans `Events.cs` — sérialisés en JSON et envoyés aux webhooks :
+- `series_start`, `series_end`
+- `map_picked`, `map_vetoed`, `map_result`
+- `round_end`, `game_paused`, `game_unpaused`
+- `game_round_live`
+- `demo_upload_ended`
+- `player_death`, `bomb_planted`, `bomb_defused`
+
+## Variables de config importantes (config.cfg)
+
+| Variable | Description |
+|----------|-------------|
+| `matchzy_knife_enabled_default` | Activer le round couteau |
+| `matchzy_minimum_ready_required` | Minimum de joueurs prêts |
+| `matchzy_demo_recording_enabled` | Enregistrement automatique des démos |
+| `matchzy_demo_path` | Dossier de stockage des démos |
+| `matchzy_demo_name_format` | Template du nom de fichier démo |
+| `matchzy_stop_command_available` | Autoriser la commande stop/restore |
+| `matchzy_use_pause_command_for_tactical_pause` | Comportement de la pause |
+| `matchzy_whitelist_enabled_default` | Activer la whitelist joueurs |
+
+## Règles de développement
+
+- Les handlers d'événements CS2 qui capturent des valeurs natives doivent le faire sur le thread principal **avant** tout `Task.Run` (voir commit fefbec6 — bug threading dans `EventRoundFreezeEnd`)
+- Toute nouvelle commande joueur/admin s'enregistre dans `ConsoleCommands.cs`
+- Tout nouvel événement publié vers G5API/webhooks doit avoir sa classe dans `Events.cs`
+- Les messages affichés aux joueurs passent par le système de localisation (`lang/`)
+- Ne jamais hardcoder de chaînes visibles par les joueurs — toujours utiliser les clés i18n
+- Les nouvelles positions spawn coach (par map) vont dans `spawns/coach/`

--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -84,6 +84,15 @@ namespace MatchZy
             resetCvarsOnSeriesEnd = bool.TryParse(args, out bool resetCvarsOnSeriesEndValue) ? resetCvarsOnSeriesEndValue : args != "0" && resetCvarsOnSeriesEnd;
         }
 
+        [ConsoleCommand("matchzy_kick_on_series_end", "Whether to kick all players when the match ends. Default value: false")]
+        public void MatchZyKickOnSeriesEndConvar(CCSPlayerController? player, CommandInfo command)
+        {
+            if (player != null) return;
+            string args = command.ArgString;
+
+            kickOnSeriesEnd = bool.TryParse(args, out bool kickOnSeriesEndValue) ? kickOnSeriesEndValue : args != "0" && kickOnSeriesEnd;
+        }
+
         [ConsoleCommand("matchzy_minimum_ready_required", "Minimum ready players required to start the match. Default: 1")]
         public void MatchZyMinimumReadyRequired(CCSPlayerController? player, CommandInfo command)
         {

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -523,6 +523,7 @@ namespace MatchZy
                 return;
             }
             string currentMapName = Server.MapName;
+            StopTvForMapChange();
             if (long.TryParse(currentMapName, out _))
             { // Check if mapName is a long for workshop map ids
                 Server.ExecuteCommand($"bot_kick");

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -273,6 +273,20 @@ namespace MatchZy
                     isPaused = false;
                     unpauseData["ct"] = false;
                     unpauseData["t"] = false;
+                    string unpauseSide = (player?.TeamNum == 2) ? "T" : "CT";
+                    string unpauseTeam = (player?.TeamNum == 2)
+                        ? ((reverseTeamSides["TERRORIST"] == matchzyTeam1) ? "team1" : "team2")
+                        : ((reverseTeamSides["CT"] == matchzyTeam1) ? "team1" : "team2");
+                    string pauseType = currentPauseType;
+                    currentPauseType = "";
+                    Task.Run(async () => await SendEventAsync(new MatchZyMatchPausedUnpausedEvent(false)
+                    {
+                        MatchId = liveMatchId,
+                        MapNumber = matchConfig.CurrentMapNumber,
+                        Team = unpauseTeam,
+                        PauseType = pauseType,
+                        Side = unpauseSide
+                    }));
                 }
                 else if (unpauseTeamName == "Admin")
                 {
@@ -315,6 +329,16 @@ namespace MatchZy
                     if (gameRules.TerroristTimeOuts > 0)
                     {
                         Server.ExecuteCommand("timeout_terrorist_start");
+                        string tacTTeam = (reverseTeamSides["TERRORIST"] == matchzyTeam1) ? "team1" : "team2";
+                        currentPauseType = "tactical";
+                        Task.Run(async () => await SendEventAsync(new MatchZyMatchPausedUnpausedEvent(true)
+                        {
+                            MatchId = liveMatchId,
+                            MapNumber = matchConfig.CurrentMapNumber,
+                            Team = tacTTeam,
+                            PauseType = "tactical",
+                            Side = "T"
+                        }));
                     }
                     else
                     {
@@ -327,6 +351,16 @@ namespace MatchZy
                     if (gameRules.CTTimeOuts > 0)
                     {
                         Server.ExecuteCommand("timeout_ct_start");
+                        string tacCTTeam = (reverseTeamSides["CT"] == matchzyTeam1) ? "team1" : "team2";
+                        currentPauseType = "tactical";
+                        Task.Run(async () => await SendEventAsync(new MatchZyMatchPausedUnpausedEvent(true)
+                        {
+                            MatchId = liveMatchId,
+                            MapNumber = matchConfig.CurrentMapNumber,
+                            Team = tacCTTeam,
+                            PauseType = "tactical",
+                            Side = "CT"
+                        }));
                     }
                     else
                     {

--- a/ConsoleCommands.cs
+++ b/ConsoleCommands.cs
@@ -200,6 +200,12 @@ namespace MatchZy
             PauseMatch(player, command);
         }
 
+        [ConsoleCommand("css_tec", "Pause the match")]
+        public void OnTecCommand(CCSPlayerController? player, CommandInfo? command)
+        {
+            PauseMatch(player, command);
+        }
+
         [ConsoleCommand("css_pause", "Pause the match")]
         public void OnPauseCommand(CCSPlayerController? player, CommandInfo? command)
         {

--- a/DatabaseStats.cs
+++ b/DatabaseStats.cs
@@ -148,6 +148,16 @@ namespace MatchZy
                     head_shot_kills INTEGER NOT NULL,
                     cash_earned INTEGER NOT NULL,
                     enemies_flashed INTEGER NOT NULL,
+                    bomb_plants INTEGER NOT NULL DEFAULT 0,
+                    bomb_defuses INTEGER NOT NULL DEFAULT 0,
+                    knife_kills INTEGER NOT NULL DEFAULT 0,
+                    friendlies_flashed INTEGER NOT NULL DEFAULT 0,
+                    teamkill INTEGER NOT NULL DEFAULT 0,
+                    suicide INTEGER NOT NULL DEFAULT 0,
+                    first_kill_t INTEGER NOT NULL DEFAULT 0,
+                    first_kill_ct INTEGER NOT NULL DEFAULT 0,
+                    first_death_t INTEGER NOT NULL DEFAULT 0,
+                    first_death_ct INTEGER NOT NULL DEFAULT 0,
                     PRIMARY KEY (matchid, mapnumber, steamid64),
                     FOREIGN KEY (matchid) REFERENCES matchzy_stats_matches (matchid),
                     FOREIGN KEY (matchid, mapnumber) REFERENCES matchzy_stats_maps (matchid, mapnumber)
@@ -223,8 +233,18 @@ namespace MatchZy
                 head_shot_kills INT NOT NULL,
                 cash_earned INT NOT NULL,
                 enemies_flashed INT NOT NULL,
+                bomb_plants INT NOT NULL DEFAULT 0,
+                bomb_defuses INT NOT NULL DEFAULT 0,
+                knife_kills INT NOT NULL DEFAULT 0,
+                friendlies_flashed INT NOT NULL DEFAULT 0,
+                teamkill INT NOT NULL DEFAULT 0,
+                suicide INT NOT NULL DEFAULT 0,
+                first_kill_t INT NOT NULL DEFAULT 0,
+                first_kill_ct INT NOT NULL DEFAULT 0,
+                first_death_t INT NOT NULL DEFAULT 0,
+                first_death_ct INT NOT NULL DEFAULT 0,
                 PRIMARY KEY (matchid, mapnumber, steamid64),
-                CONSTRAINT fk_player_map_ref FOREIGN KEY (matchid, mapnumber) 
+                CONSTRAINT fk_player_map_ref FOREIGN KEY (matchid, mapnumber)
                     REFERENCES matchzy_stats_maps (matchid, mapnumber)
             )");
         }
@@ -385,7 +405,9 @@ namespace MatchZy
                         health_points_removed_total, health_points_dealt_total, shots_fired_total,
                         shots_on_target_total, v1_count, v1_wins, v2_count, v2_wins, entry_count, entry_wins,
                         equipment_value, money_saved, kill_reward, live_time, head_shot_kills,
-                        cash_earned, enemies_flashed)
+                        cash_earned, enemies_flashed,
+                        bomb_plants, bomb_defuses, knife_kills, friendlies_flashed,
+                        teamkill, suicide, first_kill_t, first_kill_ct, first_death_t, first_death_ct)
                     VALUES (
                         @matchId, @mapNumber, @steamid64, @team, @name, @kills, @deaths, @damage, @assists,
                         @enemy5ks, @enemy4ks, @enemy3ks, @enemy2ks, @utility_count, @utility_damage,
@@ -393,7 +415,9 @@ namespace MatchZy
                         @health_points_removed_total, @health_points_dealt_total, @shots_fired_total,
                         @shots_on_target_total, @v1_count, @v1_wins, @v2_count, @v2_wins, @entry_count,
                         @entry_wins, @equipment_value, @money_saved, @kill_reward, @live_time,
-                        @head_shot_kills, @cash_earned, @enemies_flashed)
+                        @head_shot_kills, @cash_earned, @enemies_flashed,
+                        @bomb_plants, @bomb_defuses, @knife_kills, @friendlies_flashed,
+                        @teamkill, @suicide, @first_kill_t, @first_kill_ct, @first_death_t, @first_death_ct)
                     ON DUPLICATE KEY UPDATE
                         team = @team, name = @name, kills = @kills, deaths = @deaths, damage = @damage,
                         assists = @assists, enemy5ks = @enemy5ks, enemy4ks = @enemy4ks, enemy3ks = @enemy3ks,
@@ -407,7 +431,11 @@ namespace MatchZy
                         entry_count = @entry_count, entry_wins = @entry_wins,
                         equipment_value = @equipment_value, money_saved = @money_saved,
                         kill_reward = @kill_reward, live_time = @live_time, head_shot_kills = @head_shot_kills,
-                        cash_earned = @cash_earned, enemies_flashed = @enemies_flashed";
+                        cash_earned = @cash_earned, enemies_flashed = @enemies_flashed,
+                        bomb_plants = @bomb_plants, bomb_defuses = @bomb_defuses, knife_kills = @knife_kills,
+                        friendlies_flashed = @friendlies_flashed, teamkill = @teamkill, suicide = @suicide,
+                        first_kill_t = @first_kill_t, first_kill_ct = @first_kill_ct,
+                        first_death_t = @first_death_t, first_death_ct = @first_death_ct";
 
                     if (connection is SqliteConnection) {
                         sqlQuery = @"
@@ -418,7 +446,9 @@ namespace MatchZy
                             health_points_removed_total, health_points_dealt_total, shots_fired_total,
                             shots_on_target_total, v1_count, v1_wins, v2_count, v2_wins, entry_count, entry_wins,
                             equipment_value, money_saved, kill_reward, live_time, head_shot_kills,
-                            cash_earned, enemies_flashed)
+                            cash_earned, enemies_flashed,
+                            bomb_plants, bomb_defuses, knife_kills, friendlies_flashed,
+                            teamkill, suicide, first_kill_t, first_kill_ct, first_death_t, first_death_ct)
                         VALUES (
                             @matchId, @mapNumber, @steamid64, @team, @name, @kills, @deaths, @damage, @assists,
                             @enemy5ks, @enemy4ks, @enemy3ks, @enemy2ks, @utility_count, @utility_damage,
@@ -426,7 +456,9 @@ namespace MatchZy
                             @health_points_removed_total, @health_points_dealt_total, @shots_fired_total,
                             @shots_on_target_total, @v1_count, @v1_wins, @v2_count, @v2_wins, @entry_count,
                             @entry_wins, @equipment_value, @money_saved, @kill_reward, @live_time,
-                            @head_shot_kills, @cash_earned, @enemies_flashed)";
+                            @head_shot_kills, @cash_earned, @enemies_flashed,
+                            @bomb_plants, @bomb_defuses, @knife_kills, @friendlies_flashed,
+                            @teamkill, @suicide, @first_kill_t, @first_kill_ct, @first_death_t, @first_death_ct)";
                     }
 
                     await connection.ExecuteAsync(sqlQuery,
@@ -467,7 +499,17 @@ namespace MatchZy
                             live_time = playerStats["LiveTime"],
                             head_shot_kills = playerStats["HeadShotKills"],
                             cash_earned = playerStats["CashEarned"],
-                            enemies_flashed = playerStats["EnemiesFlashed"]
+                            enemies_flashed = playerStats["EnemiesFlashed"],
+                            bomb_plants = playerStats["BombPlants"],
+                            bomb_defuses = playerStats["BombDefuses"],
+                            knife_kills = playerStats["KnifeKills"],
+                            friendlies_flashed = playerStats["FriendliesFlashed"],
+                            teamkill = playerStats["TeamKills"],
+                            suicide = playerStats["Suicides"],
+                            first_kill_t = playerStats["FirstKillT"],
+                            first_kill_ct = playerStats["FirstKillCT"],
+                            first_death_t = playerStats["FirstDeathT"],
+                            first_death_ct = playerStats["FirstDeathCT"]
                         });
 
                     Log($"[UpdatePlayerStats] Data inserted/updated for player {steamid64} in match {matchId}");

--- a/DatabaseStats.cs
+++ b/DatabaseStats.cs
@@ -162,6 +162,30 @@ namespace MatchZy
                     FOREIGN KEY (matchid) REFERENCES matchzy_stats_matches (matchid),
                     FOREIGN KEY (matchid, mapnumber) REFERENCES matchzy_stats_maps (matchid, mapnumber)
                 )");
+
+            // Migrate existing tables: add new columns if they don't exist yet
+            var newColumns = new[]
+            {
+                ("bomb_plants",       "INTEGER NOT NULL DEFAULT 0"),
+                ("bomb_defuses",      "INTEGER NOT NULL DEFAULT 0"),
+                ("knife_kills",       "INTEGER NOT NULL DEFAULT 0"),
+                ("friendlies_flashed","INTEGER NOT NULL DEFAULT 0"),
+                ("teamkill",          "INTEGER NOT NULL DEFAULT 0"),
+                ("suicide",           "INTEGER NOT NULL DEFAULT 0"),
+                ("first_kill_t",      "INTEGER NOT NULL DEFAULT 0"),
+                ("first_kill_ct",     "INTEGER NOT NULL DEFAULT 0"),
+                ("first_death_t",     "INTEGER NOT NULL DEFAULT 0"),
+                ("first_death_ct",    "INTEGER NOT NULL DEFAULT 0"),
+            };
+            var existingColumns = connection.Query<string>("SELECT name FROM pragma_table_info('matchzy_stats_players')").ToHashSet();
+            foreach (var (col, def) in newColumns)
+            {
+                if (!existingColumns.Contains(col))
+                {
+                    connection.Execute($"ALTER TABLE matchzy_stats_players ADD COLUMN {col} {def}");
+                    Log($"[InitializeDatabase] Migration: added column '{col}' to matchzy_stats_players");
+                }
+            }
         }
 
         public void CreateRequiredTablesSQL()
@@ -247,6 +271,25 @@ namespace MatchZy
                 CONSTRAINT fk_player_map_ref FOREIGN KEY (matchid, mapnumber)
                     REFERENCES matchzy_stats_maps (matchid, mapnumber)
             )");
+
+            // Migrate existing tables: add new columns if they don't exist yet
+            var mysqlNewColumns = new[]
+            {
+                ("bomb_plants",       "INT NOT NULL DEFAULT 0"),
+                ("bomb_defuses",      "INT NOT NULL DEFAULT 0"),
+                ("knife_kills",       "INT NOT NULL DEFAULT 0"),
+                ("friendlies_flashed","INT NOT NULL DEFAULT 0"),
+                ("teamkill",          "INT NOT NULL DEFAULT 0"),
+                ("suicide",           "INT NOT NULL DEFAULT 0"),
+                ("first_kill_t",      "INT NOT NULL DEFAULT 0"),
+                ("first_kill_ct",     "INT NOT NULL DEFAULT 0"),
+                ("first_death_t",     "INT NOT NULL DEFAULT 0"),
+                ("first_death_ct",    "INT NOT NULL DEFAULT 0"),
+            };
+            foreach (var (col, def) in mysqlNewColumns)
+            {
+                connection.Execute($"ALTER TABLE matchzy_stats_players ADD COLUMN IF NOT EXISTS {col} {def}");
+            }
         }
 
         public long InitMatch(string team1name, string team2name, string serverIp, bool isMatchSetup, long liveMatchId, int mapNumber, string seriesType, MatchConfig matchConfig)

--- a/DemoManagement.cs
+++ b/DemoManagement.cs
@@ -86,6 +86,17 @@ namespace MatchZy
             });
         }
 
+        public void StopTvForMapChange()
+        {
+            bool tvBroadcast = ConVar.Find("tv_broadcast")!.GetPrimitiveValue<bool>();
+            if (tvBroadcast) Server.ExecuteCommand("tv_broadcast 0");
+            if (isDemoRecording)
+            {
+                Server.ExecuteCommand("tv_stoprecord");
+                isDemoRecording = false;
+            }
+        }
+
         public int GetTvDelay()
         {
             bool tvEnable = ConVar.Find("tv_enable")!.GetPrimitiveValue<bool>();

--- a/DemoManagement.cs
+++ b/DemoManagement.cs
@@ -71,6 +71,8 @@ namespace MatchZy
             {
                 if (isDemoRecording)
                 {
+                    bool tvBroadcast = ConVar.Find("tv_broadcast")!.GetPrimitiveValue<bool>();
+                    if (tvBroadcast) Server.ExecuteCommand("tv_broadcast 0");
                     Server.ExecuteCommand($"tv_stoprecord");
                 }
                 isDemoRecording = false;

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -289,6 +289,53 @@ public partial class MatchZy
                     info.DontBroadcast = true;
                 }
             }
+
+            // ── Live match stat tracking ──────────────────────────────────────────
+            if (isMatchLive)
+            {
+                CCSPlayerController? victim   = @event.Userid;
+                CCSPlayerController? attacker = @event.Attacker;
+                CCSPlayerController? assister = @event.Assister;
+                bool isSuicide = attacker == null || attacker == victim;
+
+                if (IsPlayerValid(victim))
+                {
+                    ulong victimSteamId = victim!.SteamID;
+
+                    // Knife kill
+                    if (!isSuicide && IsPlayerValid(attacker))
+                    {
+                        string weapon = @event.Weapon ?? "";
+                        if (weapon.Contains("knife") || weapon == "knifegg")
+                            IncrementStat(playerKnifeKills, attacker!.SteamID);
+
+                        // KAST: K for attacker
+                        if (attacker!.TeamNum != victim.TeamNum)
+                            MarkKast(attacker.SteamID, "K");
+                    }
+
+                    // KAST: A for assister
+                    if (IsPlayerValid(assister) && assister!.TeamNum != victim.TeamNum)
+                        MarkKast(assister.SteamID, "A");
+
+                    // Trade detection: check if victim's killer was recently killed
+                    var now = DateTime.UtcNow;
+                    foreach (var (deadSteamId, entry) in recentDeaths)
+                    {
+                        if (entry.killerSteamId == victimSteamId &&
+                            (now - entry.time).TotalSeconds <= 5.0)
+                        {
+                            // The victim just killed someone who had killed deadSteamId → trade
+                            MarkKast(deadSteamId, "T");
+                        }
+                    }
+
+                    // Record this death for future trade detection
+                    if (!isSuicide && IsPlayerValid(attacker))
+                        recentDeaths[victimSteamId] = (now, attacker!.SteamID);
+                }
+            }
+
             return HookResult.Continue;
         }
         catch (Exception e)

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -184,8 +184,8 @@ public partial class MatchZy
             {
                 Task.Run(async () => await SendEventAsync(new MatchZyRoundLiveEvent
                 {
-                    MatchId = matchConfig.MatchId,
-                    MapNumber = mapNumber,
+                    MatchId = liveMatchId,
+                    MapNumber = matchConfig.CurrentMapNumber,
                     RoundNumber = GetRoundNumer(),
                 }));
             }

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -381,6 +381,86 @@ public partial class MatchZy
                     if (!isSuicide && IsPlayerValid(attacker))
                         recentDeaths[victimSteamId] = (now, attacker!.SteamID);
                 }
+
+                // Send player_death event to G5API
+                if (IsPlayerValid(victim))
+                {
+                    string victimSide = victim!.TeamNum == (int)CsTeam.Terrorist ? "T"
+                                      : victim.TeamNum == (int)CsTeam.CounterTerrorist ? "CT" : "";
+                    bool isAttackerValid = !isSuicide && IsPlayerValid(attacker);
+                    string attackerSide = isAttackerValid
+                        ? (attacker!.TeamNum == (int)CsTeam.Terrorist ? "T"
+                           : attacker.TeamNum == (int)CsTeam.CounterTerrorist ? "CT" : "")
+                        : "";
+
+                    string weaponName = @event.Weapon ?? "";
+                    bool isBomb = weaponName == "planted_c4" || weaponName == "explosion";
+                    bool isFriendlyFire = isAttackerValid && attacker!.TeamNum == victim.TeamNum;
+
+                    MatchZyDeathAssist? assist = null;
+                    if (IsPlayerValid(assister))
+                    {
+                        string assisterSide = assister!.TeamNum == (int)CsTeam.Terrorist ? "T"
+                                            : assister.TeamNum == (int)CsTeam.CounterTerrorist ? "CT" : "";
+                        assist = new MatchZyDeathAssist
+                        {
+                            Player = new MatchZyDeathPlayerInfo
+                            {
+                                SteamId = assister.SteamID.ToString(),
+                                Name = assister.PlayerName,
+                                Side = assisterSide,
+                                IsBot = assister.IsBot,
+                            },
+                            FriendlyFire = assister.TeamNum == victim.TeamNum,
+                            FlashAssist = @event.AssistedFlash,
+                        };
+                    }
+
+                    long capturedMatchId = liveMatchId;
+                    int capturedMapNumber = matchConfig.CurrentMapNumber;
+                    int capturedRoundNumber = GetRoundNumer();
+
+                    var deathEvent = new MatchZyPlayerDeathEvent
+                    {
+                        MatchId = capturedMatchId,
+                        MapNumber = capturedMapNumber,
+                        RoundNumber = capturedRoundNumber,
+                        RoundTime = 0,
+                        Player = new MatchZyDeathPlayerInfo
+                        {
+                            SteamId = victim.SteamID.ToString(),
+                            Name = victim.PlayerName,
+                            Side = victimSide,
+                            IsBot = victim.IsBot,
+                        },
+                        Weapon = new MatchZyDeathWeapon { Name = weaponName },
+                        Bomb = isBomb,
+                        Headshot = @event.Headshot,
+                        ThruSmoke = @event.ThruSmoke,
+                        Penetrated = @event.Penetrated > 0,
+                        AttackerBlind = @event.AttackerBlind,
+                        NoScope = @event.Noscope,
+                        Suicide = isSuicide,
+                        FriendlyFire = isFriendlyFire,
+                        Attacker = isAttackerValid
+                            ? new MatchZyDeathPlayerInfo
+                            {
+                                SteamId = attacker!.SteamID.ToString(),
+                                Name = attacker.PlayerName,
+                                Side = attackerSide,
+                                IsBot = attacker.IsBot,
+                            }
+                            : new MatchZyDeathPlayerInfo
+                            {
+                                SteamId = victim.SteamID.ToString(),
+                                Name = victim.PlayerName,
+                                Side = victimSide,
+                                IsBot = victim.IsBot,
+                            },
+                        Assist = assist,
+                    };
+                    Task.Run(async () => await SendEventAsync(deathEvent));
+                }
             }
 
             return HookResult.Continue;

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -315,16 +315,50 @@ public partial class MatchZy
                 {
                     ulong victimSteamId = victim!.SteamID;
 
-                    // Knife kill
+                    // Suicide
+                    if (isSuicide)
+                    {
+                        IncrementStat(playerSuicides, victimSteamId);
+                    }
+
                     if (!isSuicide && IsPlayerValid(attacker))
                     {
                         string weapon = @event.Weapon ?? "";
+
+                        // Knife kill
                         if (weapon.Contains("knife") || weapon == "knifegg")
                             IncrementStat(playerKnifeKills, attacker!.SteamID);
 
-                        // KAST: K for attacker
-                        if (attacker!.TeamNum != victim.TeamNum)
+                        // Teamkill vs enemy kill
+                        if (attacker!.TeamNum == victim.TeamNum)
+                        {
+                            IncrementStat(playerTeamKills, attacker.SteamID);
+                        }
+                        else
+                        {
+                            // KAST: K for attacker (only enemy kills)
                             MarkKast(attacker.SteamID, "K");
+
+                            // First kill of the round (enemy kills only)
+                            if (!roundFirstKillDone)
+                            {
+                                roundFirstKillDone = true;
+                                if (attacker.TeamNum == (int)CsTeam.Terrorist)
+                                    IncrementStat(playerFirstKillT, attacker.SteamID);
+                                else if (attacker.TeamNum == (int)CsTeam.CounterTerrorist)
+                                    IncrementStat(playerFirstKillCT, attacker.SteamID);
+                            }
+                        }
+                    }
+
+                    // First death of the round (any non-suicide death)
+                    if (!isSuicide && !roundFirstDeathDone)
+                    {
+                        roundFirstDeathDone = true;
+                        if (victim.TeamNum == (int)CsTeam.Terrorist)
+                            IncrementStat(playerFirstDeathT, victimSteamId);
+                        else if (victim.TeamNum == (int)CsTeam.CounterTerrorist)
+                            IncrementStat(playerFirstDeathCT, victimSteamId);
                     }
 
                     // KAST: A for assister

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -182,11 +182,14 @@ public partial class MatchZy
 
             if (isMatchLive)
             {
+                long capturedMatchId = liveMatchId;
+                int capturedMapNumber = matchConfig.CurrentMapNumber;
+                int capturedRoundNumber = GetRoundNumer();
                 Task.Run(async () => await SendEventAsync(new MatchZyRoundLiveEvent
                 {
-                    MatchId = liveMatchId,
-                    MapNumber = matchConfig.CurrentMapNumber,
-                    RoundNumber = GetRoundNumer(),
+                    MatchId = capturedMatchId,
+                    MapNumber = capturedMapNumber,
+                    RoundNumber = capturedRoundNumber,
                 }));
             }
             return HookResult.Continue;

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -179,6 +179,16 @@ public partial class MatchZy
                     AddTimer(0.01f, () => coach.ChangeTeam(oldTeam));
                 });
             }
+
+            if (isMatchLive)
+            {
+                Task.Run(async () => await SendEventAsync(new MatchZyRoundLiveEvent
+                {
+                    MatchId = matchConfig.MatchId,
+                    MapNumber = mapNumber,
+                    RoundNumber = GetRoundNumer(),
+                }));
+            }
             return HookResult.Continue;
         }
         catch (Exception e)

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -412,7 +412,7 @@ public partial class MatchZy
                                 IsBot = assister.IsBot,
                             },
                             FriendlyFire = assister.TeamNum == victim.TeamNum,
-                            FlashAssist = @event.AssistedFlash,
+                            FlashAssist = @event.Assistedflash,
                         };
                     }
 
@@ -436,9 +436,9 @@ public partial class MatchZy
                         Weapon = new MatchZyDeathWeapon { Name = weaponName },
                         Bomb = isBomb,
                         Headshot = @event.Headshot,
-                        ThruSmoke = @event.ThruSmoke,
+                        ThruSmoke = @event.Thrusmoke,
                         Penetrated = @event.Penetrated > 0,
-                        AttackerBlind = @event.AttackerBlind,
+                        AttackerBlind = @event.Attackerblind,
                         NoScope = @event.Noscope,
                         Suicide = isSuicide,
                         FriendlyFire = isFriendlyFire,

--- a/Events.cs
+++ b/Events.cs
@@ -262,3 +262,81 @@ public class MatchZyMatchPausedUnpausedEvent : MatchZyMapEvent
     {
     }
 }
+
+// ── Player death event ─────────────────────────────────────────────────────
+
+public class MatchZyDeathPlayerInfo
+{
+    [JsonPropertyName("steamid")]
+    public required string SteamId { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("side")]
+    public required string Side { get; init; }
+
+    [JsonPropertyName("is_bot")]
+    public required bool IsBot { get; init; }
+}
+
+public class MatchZyDeathWeapon
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+}
+
+public class MatchZyDeathAssist
+{
+    [JsonPropertyName("player")]
+    public required MatchZyDeathPlayerInfo Player { get; init; }
+
+    [JsonPropertyName("friendly_fire")]
+    public required bool FriendlyFire { get; init; }
+
+    [JsonPropertyName("flash_assist")]
+    public required bool FlashAssist { get; init; }
+}
+
+public class MatchZyPlayerDeathEvent : MatchZyTimedRoundEvent
+{
+    [JsonPropertyName("player")]
+    public required MatchZyDeathPlayerInfo Player { get; init; }
+
+    [JsonPropertyName("weapon")]
+    public required MatchZyDeathWeapon Weapon { get; init; }
+
+    [JsonPropertyName("bomb")]
+    public required bool Bomb { get; init; }
+
+    [JsonPropertyName("headshot")]
+    public required bool Headshot { get; init; }
+
+    [JsonPropertyName("thru_smoke")]
+    public required bool ThruSmoke { get; init; }
+
+    [JsonPropertyName("penetrated")]
+    public required bool Penetrated { get; init; }
+
+    [JsonPropertyName("attacker_blind")]
+    public required bool AttackerBlind { get; init; }
+
+    [JsonPropertyName("no_scope")]
+    public required bool NoScope { get; init; }
+
+    [JsonPropertyName("suicide")]
+    public required bool Suicide { get; init; }
+
+    [JsonPropertyName("friendly_fire")]
+    public required bool FriendlyFire { get; init; }
+
+    [JsonPropertyName("attacker")]
+    public required MatchZyDeathPlayerInfo Attacker { get; init; }
+
+    [JsonPropertyName("assist")]
+    public MatchZyDeathAssist? Assist { get; init; }
+
+    public MatchZyPlayerDeathEvent() : base("player_death")
+    {
+    }
+}

--- a/Events.cs
+++ b/Events.cs
@@ -236,3 +236,19 @@ public class MatchZyDemoUploadedEvent : MatchZyMatchEvent
     {
     }
 }
+
+public class MatchZyMatchPausedUnpausedEvent : MatchZyMapEvent
+{
+    [JsonPropertyName("team")]
+    public required string Team { get; init; }
+
+    [JsonPropertyName("pause_type")]
+    public required string PauseType { get; init; }
+
+    [JsonPropertyName("side")]
+    public required string Side { get; init; }
+
+    public MatchZyMatchPausedUnpausedEvent(bool paused) : base(paused ? "game_paused" : "game_unpaused")
+    {
+    }
+}

--- a/Events.cs
+++ b/Events.cs
@@ -237,6 +237,16 @@ public class MatchZyDemoUploadedEvent : MatchZyMatchEvent
     }
 }
 
+public class MatchZyRoundLiveEvent : MatchZyMapEvent
+{
+    [JsonPropertyName("round_number")]
+    public required int RoundNumber { get; init; }
+
+    public MatchZyRoundLiveEvent() : base("game_round_live")
+    {
+    }
+}
+
 public class MatchZyMatchPausedUnpausedEvent : MatchZyMapEvent
 {
     [JsonPropertyName("team")]

--- a/MatchManagement.cs
+++ b/MatchManagement.cs
@@ -20,6 +20,7 @@ namespace MatchZy
         public bool matchModeOnly = false;
 
         public bool resetCvarsOnSeriesEnd = true;
+        public bool kickOnSeriesEnd = false;
 
         public string loadedConfigFile = "";
 
@@ -608,6 +609,16 @@ namespace MatchZy
 
             if (resetCvarsOnSeriesEnd) ResetChangedConvars();
             isMatchLive = false;
+            if (kickOnSeriesEnd)
+            {
+                AddTimer(restartDelay, () => {
+                    var players = Utilities.GetPlayers().Where(p => p != null && p.IsValid && !p.IsBot);
+                    foreach (var p in players)
+                    {
+                        KickPlayer(p);
+                    }
+                });
+            }
             AddTimer(restartDelay, () => {
                 ResetMatch(false);
             });

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -14,7 +14,7 @@ namespace MatchZy
 
         public override string ModuleName => "MatchZy";
 
-        public override string ModuleVersion => "0.8.15";
+        public override string ModuleVersion => "0.8.17-dev";
 
         public override string ModuleAuthor => "WD- (https://github.com/shobhit-pathak/)";
 

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -14,7 +14,7 @@ namespace MatchZy
 
         public override string ModuleName => "MatchZy";
 
-        public override string ModuleVersion => "0.8.15";
+        public override string ModuleVersion => "0.8.16";
 
         public override string ModuleAuthor => "WD- (https://github.com/shobhit-pathak/)";
 

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -39,6 +39,7 @@ namespace MatchZy
 
         // Pause Data
         public bool isPaused = false;
+        public string currentPauseType = "";
         public Dictionary<string, object> unpauseData = new Dictionary<string, object> {
             { "ct", false },
             { "t", false },

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -518,6 +518,20 @@ namespace MatchZy
             {
                 CCSPlayerController? player = @event.Userid;
                 CCSPlayerController? attacker = @event.Attacker;
+
+                // Track flash stats during live match
+                if (isMatchLive && IsPlayerValid(player) && IsPlayerValid(attacker) && attacker!.IsValid)
+                {
+                    if (@event.BlindDuration >= 1.0f)
+                    {
+                        ulong attackerSteamId = attacker.SteamID;
+                        if (attacker.TeamNum == player!.TeamNum)
+                            IncrementStat(playerTeammatesFlashed, attackerSteamId);
+                        else
+                            IncrementStat(playerFlashAssists, attackerSteamId);
+                    }
+                }
+
                 if (!isPractice) return HookResult.Continue;
 
                 if (!IsPlayerValid(player) || !IsPlayerValid(attacker)) return HookResult.Continue;
@@ -533,6 +547,24 @@ namespace MatchZy
                     Server.NextFrame(() => KillFlashEffect(player));
                 }
 
+                return HookResult.Continue;
+            });
+
+            RegisterEventHandler<EventBombPlanted>((@event, info) =>
+            {
+                if (!isMatchLive) return HookResult.Continue;
+                CCSPlayerController? player = @event.Userid;
+                if (IsPlayerValid(player))
+                    IncrementStat(playerBombPlants, player!.SteamID);
+                return HookResult.Continue;
+            });
+
+            RegisterEventHandler<EventBombDefused>((@event, info) =>
+            {
+                if (!isMatchLive) return HookResult.Continue;
+                CCSPlayerController? player = @event.Userid;
+                if (IsPlayerValid(player))
+                    IncrementStat(playerBombDefuses, player!.SteamID);
                 return HookResult.Continue;
             });
 

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -14,7 +14,7 @@ namespace MatchZy
 
         public override string ModuleName => "MatchZy";
 
-        public override string ModuleVersion => "0.8.19";
+        public override string ModuleVersion => "0.8.20";
 
         public override string ModuleAuthor => "WD- (https://github.com/shobhit-pathak/)";
 

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -14,7 +14,7 @@ namespace MatchZy
 
         public override string ModuleName => "MatchZy";
 
-        public override string ModuleVersion => "0.8.18";
+        public override string ModuleVersion => "0.8.19";
 
         public override string ModuleAuthor => "WD- (https://github.com/shobhit-pathak/)";
 

--- a/MatchZy.cs
+++ b/MatchZy.cs
@@ -119,6 +119,7 @@ namespace MatchZy
                 { ".switch", OnTeamSwitch },
                 { ".swap", OnTeamSwitch },
                 { ".tech", OnTechCommand },
+                { ".tec", OnTechCommand },
                 { ".p", OnPauseCommand },
                 { ".pause", OnPauseCommand },
                 { ".unpause", OnUnpauseCommand },

--- a/PlayerStatsTracking.cs
+++ b/PlayerStatsTracking.cs
@@ -12,6 +12,12 @@ namespace MatchZy
         public Dictionary<ulong, int> playerBombDefuses      = new();
         public Dictionary<ulong, int> playerFlashAssists     = new();
         public Dictionary<ulong, int> playerTeammatesFlashed = new();
+        public Dictionary<ulong, int> playerTeamKills        = new();
+        public Dictionary<ulong, int> playerSuicides         = new();
+        public Dictionary<ulong, int> playerFirstKillT       = new();
+        public Dictionary<ulong, int> playerFirstKillCT      = new();
+        public Dictionary<ulong, int> playerFirstDeathT      = new();
+        public Dictionary<ulong, int> playerFirstDeathCT     = new();
 
         // KAST: accumulated rounds where the player had K, A, S or T
         public Dictionary<ulong, int> kastRoundsContributed  = new();
@@ -21,6 +27,10 @@ namespace MatchZy
 
         // victim steamid → (death timestamp, killer steamid) — used to detect traded kills
         private Dictionary<ulong, (DateTime time, ulong killerSteamId)> recentDeaths = new();
+
+        // first kill/death flags for the current round
+        private bool roundFirstKillDone  = false;
+        private bool roundFirstDeathDone = false;
 
         // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -42,6 +52,8 @@ namespace MatchZy
         {
             kastFlags.Clear();
             recentDeaths.Clear();
+            roundFirstKillDone  = false;
+            roundFirstDeathDone = false;
         }
 
         // ─── Called at round end (before GetPlayerStatsDict) ─────────────────────
@@ -77,9 +89,17 @@ namespace MatchZy
             playerBombDefuses.Clear();
             playerFlashAssists.Clear();
             playerTeammatesFlashed.Clear();
+            playerTeamKills.Clear();
+            playerSuicides.Clear();
+            playerFirstKillT.Clear();
+            playerFirstKillCT.Clear();
+            playerFirstDeathT.Clear();
+            playerFirstDeathCT.Clear();
             kastRoundsContributed.Clear();
             kastFlags.Clear();
             recentDeaths.Clear();
+            roundFirstKillDone  = false;
+            roundFirstDeathDone = false;
         }
     }
 }

--- a/PlayerStatsTracking.cs
+++ b/PlayerStatsTracking.cs
@@ -1,0 +1,85 @@
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
+
+namespace MatchZy
+{
+    public partial class MatchZy
+    {
+        // ─── Per-player cumulative stats (reset on match reset) ───────────────────
+        public Dictionary<ulong, int> playerKnifeKills       = new();
+        public Dictionary<ulong, int> playerBombPlants       = new();
+        public Dictionary<ulong, int> playerBombDefuses      = new();
+        public Dictionary<ulong, int> playerFlashAssists     = new();
+        public Dictionary<ulong, int> playerTeammatesFlashed = new();
+
+        // KAST: accumulated rounds where the player had K, A, S or T
+        public Dictionary<ulong, int> kastRoundsContributed  = new();
+
+        // ─── Per-round state (reset each round start) ─────────────────────────────
+        private Dictionary<ulong, HashSet<string>> kastFlags = new();
+
+        // victim steamid → (death timestamp, killer steamid) — used to detect traded kills
+        private Dictionary<ulong, (DateTime time, ulong killerSteamId)> recentDeaths = new();
+
+        // ─── Helpers ──────────────────────────────────────────────────────────────
+
+        private void MarkKast(ulong steamId, string flag)
+        {
+            if (!kastFlags.ContainsKey(steamId))
+                kastFlags[steamId] = new HashSet<string>();
+            kastFlags[steamId].Add(flag);
+        }
+
+        private void IncrementStat(Dictionary<ulong, int> dict, ulong steamId)
+        {
+            dict.TryGetValue(steamId, out int v);
+            dict[steamId] = v + 1;
+        }
+
+        // ─── Called at round start ────────────────────────────────────────────────
+        public void ResetPerRoundKastState()
+        {
+            kastFlags.Clear();
+            recentDeaths.Clear();
+        }
+
+        // ─── Called at round end (before GetPlayerStatsDict) ─────────────────────
+        public void FinalizeKastForRound()
+        {
+            // S: mark players still alive at round end
+            foreach (var player in playerData.Values)
+            {
+                if (!player.IsValid || player.IsHLTV || player.IsBot) continue;
+                if (player.TeamNum != (int)CsTeam.CounterTerrorist &&
+                    player.TeamNum != (int)CsTeam.Terrorist) continue;
+
+                if (player.PlayerPawn?.Value?.LifeState == (byte)LifeState_t.LIFE_ALIVE)
+                    MarkKast(player.SteamID, "S");
+            }
+
+            // Accumulate KAST rounds for any player who had at least one flag
+            foreach (var (steamId, flags) in kastFlags)
+            {
+                if (flags.Count > 0)
+                {
+                    kastRoundsContributed.TryGetValue(steamId, out int cur);
+                    kastRoundsContributed[steamId] = cur + 1;
+                }
+            }
+        }
+
+        // ─── Called on match reset ────────────────────────────────────────────────
+        public void ResetMatchStats()
+        {
+            playerKnifeKills.Clear();
+            playerBombPlants.Clear();
+            playerBombDefuses.Clear();
+            playerFlashAssists.Clear();
+            playerTeammatesFlashed.Clear();
+            kastRoundsContributed.Clear();
+            kastFlags.Clear();
+            recentDeaths.Clear();
+        }
+    }
+}

--- a/Utility.cs
+++ b/Utility.cs
@@ -1213,7 +1213,22 @@ namespace MatchZy
                 PrintToAllChat(Localizer["matchzy.pause.pausedthematch", pauseTeamName]);
                 // Server.PrintToChatAll($"{chatPrefix} {ChatColors.Green}{pauseTeamName}{ChatColors.Default} has paused the match. Type .unpause to unpause the match");
 
+                string techPauseSide = (player?.TeamNum == 2) ? "T" : "CT";
+                string techPauseTeam = (player?.TeamNum == 2)
+                    ? ((reverseTeamSides["TERRORIST"] == matchzyTeam1) ? "team1" : "team2")
+                    : ((reverseTeamSides["CT"] == matchzyTeam1) ? "team1" : "team2");
+                currentPauseType = "tech";
+
                 SetMatchPausedFlags();
+
+                Task.Run(async () => await SendEventAsync(new MatchZyMatchPausedUnpausedEvent(true)
+                {
+                    MatchId = liveMatchId,
+                    MapNumber = matchConfig.CurrentMapNumber,
+                    Team = techPauseTeam,
+                    PauseType = "tech",
+                    Side = techPauseSide
+                }));
             }
         }
 
@@ -1256,7 +1271,17 @@ namespace MatchZy
             {
                 Server.PrintToConsole($"[MatchZy] {Localizer["matchzy.pause.adminpausedthematch"]}");
             }
+            currentPauseType = "admin";
             SetMatchPausedFlags();
+
+            Task.Run(async () => await SendEventAsync(new MatchZyMatchPausedUnpausedEvent(true)
+            {
+                MatchId = liveMatchId,
+                MapNumber = matchConfig.CurrentMapNumber,
+                Team = "admin",
+                PauseType = "admin",
+                Side = "Admin"
+            }));
         }
 
         private void ForceUnpauseMatch(CCSPlayerController? player, CommandInfo? command)
@@ -1280,15 +1305,25 @@ namespace MatchZy
 
         private void UnpauseMatch()
         {
+            string pauseType = currentPauseType;
             Server.ExecuteCommand("mp_unpause_match;");
             isPaused = false;
             unpauseData["ct"] = false;
             unpauseData["t"] = false;
+            currentPauseType = "";
             if (!isPaused && pausedStateTimer != null)
             {
                 pausedStateTimer.Kill();
                 pausedStateTimer = null;
             }
+            Task.Run(async () => await SendEventAsync(new MatchZyMatchPausedUnpausedEvent(false)
+            {
+                MatchId = liveMatchId,
+                MapNumber = matchConfig.CurrentMapNumber,
+                Team = "admin",
+                PauseType = pauseType,
+                Side = "Admin"
+            }));
         }
 
         private void SetMatchPausedFlags()

--- a/Utility.cs
+++ b/Utility.cs
@@ -380,6 +380,7 @@ namespace MatchZy
                     isDemoRecording = false;
                 }
                 // Reset match data
+                ResetMatchStats();
                 matchStarted = false;
                 readyAvailable = true;
                 isPaused = false;
@@ -1035,6 +1036,7 @@ namespace MatchZy
             CreateMatchZyRoundDataBackup();
             InitPlayerDamageInfo();
             UpdateHostname();
+            if (isMatchLive) ResetPerRoundKastState();
         }
 
         private void HandlePostRoundEndEvent(EventRoundEnd @event)
@@ -1050,6 +1052,7 @@ namespace MatchZy
 
                     ShowDamageInfo();
 
+                    FinalizeKastForRound();
                     (Dictionary<ulong, Dictionary<string, object>> playerStatsDictionary, List<StatsPlayer> playerStatsListTeam1, List<StatsPlayer> playerStatsListTeam2) = GetPlayerStatsDict();
 
                     int currentMapNumber = matchConfig.CurrentMapNumber;
@@ -1669,24 +1672,31 @@ namespace MatchZy
                     playerStatsDictionary.Add(steamid64, stats);
 
                     // Populate PlayerStats instance
-                    // Todo: Implement stats which are marked as 0 for now
+                    playerFlashAssists.TryGetValue(steamid64, out int flashAssists);
+                    playerTeammatesFlashed.TryGetValue(steamid64, out int teammatesFlashed);
+                    playerKnifeKills.TryGetValue(steamid64, out int knifeKills);
+                    playerBombPlants.TryGetValue(steamid64, out int bombPlants);
+                    playerBombDefuses.TryGetValue(steamid64, out int bombDefuses);
+                    kastRoundsContributed.TryGetValue(steamid64, out int kastRounds);
+                    int kastPercent = roundsPlayed > 0 ? (int)Math.Round((double)kastRounds / roundsPlayed * 100) : 0;
+
                     PlayerStats playerStatsInstance = new()
                     {
                         Kills = playerStats.Kills,
                         Deaths = playerStats.Deaths,
                         Assists = playerStats.Assists,
-                        FlashAssists = 0,
+                        FlashAssists = flashAssists,
                         TeamKills = 0,
                         Suicides = 0,
                         Damage = playerStats.Damage,
                         UtilityDamage = playerStats.UtilityDamage,
                         EnemiesFlashed = playerStats.EnemiesFlashed,
-                        FriendliesFlashed = 0,
-                        KnifeKills = 0,
+                        FriendliesFlashed = teammatesFlashed,
+                        KnifeKills = knifeKills,
                         HeadshotKills = playerStats.HeadShotKills,
                         RoundsPlayed = roundsPlayed,
-                        BombDefuses = 0,
-                        BombPlants = 0,
+                        BombDefuses = bombDefuses,
+                        BombPlants = bombPlants,
                         Kills1 = 0,
                         Kills2 = playerStats.Enemy2Ks,
                         Kills3 = playerStats.Enemy3Ks,
@@ -1702,7 +1712,7 @@ namespace MatchZy
                         FirstDeathsT = 0,
                         FirstDeathsCT = 0,
                         TradeKills = 0,
-                        Kast = 0,
+                        Kast = kastPercent,
                         Score = player.Score,
                         Mvps = player.MVPs,
                     };

--- a/Utility.cs
+++ b/Utility.cs
@@ -515,9 +515,9 @@ namespace MatchZy
                     if (isMatchSetup || matchModeOnly)
                     {
                         CsTeam team = GetPlayerTeam(player);
-                        if (team == CsTeam.None && player.UserId.HasValue)
+                        if (team == CsTeam.None && player.IsValid)
                         {
-                            Server.ExecuteCommand($"kickid {(ushort)player.UserId}");
+                            player.Disconnect(NetworkDisconnectionReason.NETWORK_DISCONNECT_KICKED);
                             continue;
                         }
                     }
@@ -1860,9 +1860,9 @@ namespace MatchZy
 
         public void KickPlayer(CCSPlayerController player)
         {
-            if (player.UserId.HasValue)
+            if (player.IsValid)
             {
-                Server.ExecuteCommand($"kickid {(ushort)player.UserId}");
+                player.Disconnect(NetworkDisconnectionReason.NETWORK_DISCONNECT_KICKED);
             }
         }
 

--- a/Utility.cs
+++ b/Utility.cs
@@ -376,6 +376,8 @@ namespace MatchZy
                 // We stop demo recording if a live match was restarted
                 if (matchStarted && isDemoRecording)
                 {
+                    bool tvBroadcast = ConVar.Find("tv_broadcast")!.GetPrimitiveValue<bool>();
+                    if (tvBroadcast) Server.ExecuteCommand("tv_broadcast 0");
                     Server.ExecuteCommand($"tv_stoprecord");
                     isDemoRecording = false;
                 }

--- a/Utility.cs
+++ b/Utility.cs
@@ -515,9 +515,9 @@ namespace MatchZy
                     if (isMatchSetup || matchModeOnly)
                     {
                         CsTeam team = GetPlayerTeam(player);
-                        if (team == CsTeam.None && player.IsValid)
+                        if (team == CsTeam.None && player.UserId.HasValue)
                         {
-                            player.Disconnect(NetworkDisconnectionReason.NETWORK_DISCONNECT_KICKED);
+                            Server.ExecuteCommand($"kickid {(ushort)player.UserId}");
                             continue;
                         }
                     }
@@ -1860,9 +1860,9 @@ namespace MatchZy
 
         public void KickPlayer(CCSPlayerController player)
         {
-            if (player.IsValid)
+            if (player.UserId.HasValue)
             {
-                player.Disconnect(NetworkDisconnectionReason.NETWORK_DISCONNECT_KICKED);
+                Server.ExecuteCommand($"kickid {(ushort)player.UserId}");
             }
         }
 

--- a/Utility.cs
+++ b/Utility.cs
@@ -1693,7 +1693,17 @@ namespace MatchZy
                         { "LiveTime", playerStats.LiveTime },
                         { "HeadShotKills", playerStats.HeadShotKills },
                         { "CashEarned", playerStats.CashEarned },
-                        { "EnemiesFlashed", playerStats.EnemiesFlashed }
+                        { "EnemiesFlashed", playerStats.EnemiesFlashed },
+                        { "BombPlants", 0 },
+                        { "BombDefuses", 0 },
+                        { "KnifeKills", 0 },
+                        { "FriendliesFlashed", 0 },
+                        { "TeamKills", 0 },
+                        { "Suicides", 0 },
+                        { "FirstKillT", 0 },
+                        { "FirstKillCT", 0 },
+                        { "FirstDeathT", 0 },
+                        { "FirstDeathCT", 0 }
                     };
 
                     string teamName = "Spectator";
@@ -1716,8 +1726,26 @@ namespace MatchZy
                     playerKnifeKills.TryGetValue(steamid64, out int knifeKills);
                     playerBombPlants.TryGetValue(steamid64, out int bombPlants);
                     playerBombDefuses.TryGetValue(steamid64, out int bombDefuses);
+                    playerTeamKills.TryGetValue(steamid64, out int teamKills);
+                    playerSuicides.TryGetValue(steamid64, out int suicides);
+                    playerFirstKillT.TryGetValue(steamid64, out int firstKillT);
+                    playerFirstKillCT.TryGetValue(steamid64, out int firstKillCT);
+                    playerFirstDeathT.TryGetValue(steamid64, out int firstDeathT);
+                    playerFirstDeathCT.TryGetValue(steamid64, out int firstDeathCT);
                     kastRoundsContributed.TryGetValue(steamid64, out int kastRounds);
                     int kastPercent = roundsPlayed > 0 ? (int)Math.Round((double)kastRounds / roundsPlayed * 100) : 0;
+
+                    // Fill new stat fields in the dict
+                    stats["BombPlants"]       = bombPlants;
+                    stats["BombDefuses"]      = bombDefuses;
+                    stats["KnifeKills"]       = knifeKills;
+                    stats["FriendliesFlashed"] = teammatesFlashed;
+                    stats["TeamKills"]        = teamKills;
+                    stats["Suicides"]         = suicides;
+                    stats["FirstKillT"]       = firstKillT;
+                    stats["FirstKillCT"]      = firstKillCT;
+                    stats["FirstDeathT"]      = firstDeathT;
+                    stats["FirstDeathCT"]     = firstDeathCT;
 
                     PlayerStats playerStatsInstance = new()
                     {
@@ -1725,8 +1753,8 @@ namespace MatchZy
                         Deaths = playerStats.Deaths,
                         Assists = playerStats.Assists,
                         FlashAssists = flashAssists,
-                        TeamKills = 0,
-                        Suicides = 0,
+                        TeamKills = teamKills,
+                        Suicides = suicides,
                         Damage = playerStats.Damage,
                         UtilityDamage = playerStats.UtilityDamage,
                         EnemiesFlashed = playerStats.EnemiesFlashed,
@@ -1746,10 +1774,10 @@ namespace MatchZy
                         OneV3s = 0,
                         OneV4s = 0,
                         OneV5s = 0,
-                        FirstKillsT = 0,
-                        FirstKillsCT = 0,
-                        FirstDeathsT = 0,
-                        FirstDeathsCT = 0,
+                        FirstKillsT = firstKillT,
+                        FirstKillsCT = firstKillCT,
+                        FirstDeathsT = firstDeathT,
+                        FirstDeathsCT = firstDeathCT,
                         TradeKills = 0,
                         Kast = kastPercent,
                         Score = player.Score,

--- a/Utility.cs
+++ b/Utility.cs
@@ -634,6 +634,7 @@ namespace MatchZy
                 mapName = "de_" + mapName;
             }
 
+            StopTvForMapChange();
             if (long.TryParse(mapName, out _))
             { // Check if mapName is a long for workshop map ids
                 Server.ExecuteCommand($"bot_kick");
@@ -970,6 +971,7 @@ namespace MatchZy
             Log($"[ChangeMap] Changing map to {mapName} with delay {delay}");
             AddTimer(delay, () =>
             {
+                StopTvForMapChange();
                 if (long.TryParse(mapName, out _))
                 {
                     Server.ExecuteCommand($"bot_kick");

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -85,6 +85,9 @@ matchzy_kick_when_no_match_loaded false
 // Default: true
 matchzy_reset_cvars_on_series_end true
 
+// Whether to kick all players when the match ends. Default value: false
+matchzy_kick_on_series_end true
+
 // If defined, recorded demos will be uploaded to this URL once the map ends
 matchzy_demo_upload_url ""
 


### PR DESCRIPTION
## Summary

- Ajout de \`MatchZyPlayerDeathEvent\` (et helpers \`MatchZyDeathPlayerInfo\`, \`MatchZyDeathWeapon\`, \`MatchZyDeathAssist\`) dans \`Events.cs\`
- À chaque mort pendant un match live, envoie un event \`player_death\` à l'endpoint G5API via \`SendEventAsync\`
- Payload : victim, attacker, assister, weapon, headshot, thru-smoke, penetrated, attacker-blind, no-scope, suicide, friendly fire, flash assist
- Bump \`ModuleVersion\` → \`0.8.20\`

## Test plan

- [ ] Lancer un match live avec \`RemoteLogURL\` configuré
- [ ] Vérifier que les events \`player_death\` arrivent dans les logs G5API à chaque kill
- [ ] Vérifier que \`player_stat_extras\` est bien rempli
- [ ] Tester un suicide — champ \`attacker\` doit miroir la victime
- [ ] Tester un kill avec flash assist — \`flash_assist: true\`
- [ ] Tester sans assister — champ \`assist\` doit être null

🤖 Generated with [Claude Code](https://claude.com/claude-code)