### PR TITLE
Support S3-compatible presigned URL demo upload (HTTP PUT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MatchZy Changelog
 
+## Unreleased
+
+- Added `matchzy_demo_upload_s3` / `get5_demo_upload_s3` to upload demos with HTTP PUT to `matchzy_demo_upload_url` for S3-compatible presigned URLs (see documentation).
+
 # 0.8.15
 
 #### October 26, 2025

--- a/ConfigConvars.cs
+++ b/ConfigConvars.cs
@@ -149,6 +149,16 @@ namespace MatchZy
             demoUploadURL = url;
         }
 
+        [ConsoleCommand("get5_demo_upload_s3", "If true, demo upload uses HTTP PUT to matchzy_demo_upload_url (e.g. S3 presigned URL) with raw .dem body. Default value: false")]
+        [ConsoleCommand("matchzy_demo_upload_s3", "If true, demo upload uses HTTP PUT to matchzy_demo_upload_url (e.g. S3 presigned URL) with raw .dem body. Default value: false")]
+        public void MatchZyDemoUploadS3(CCSPlayerController? player, CommandInfo command)
+        {
+            if (player != null) return;
+            string args = command.ArgString;
+
+            isDemoUploadS3Enabled = bool.TryParse(args, out bool isDemoUploadS3EnabledValue) ? isDemoUploadS3EnabledValue : args != "0" && isDemoUploadS3Enabled;
+        }
+
         [ConsoleCommand("matchzy_stop_command_available", "Whether .stop command is enabled or not (to restore the current round). Default value: false")]
         public void MatchZyStopCommandEnabled(CCSPlayerController? player, CommandInfo command)
         {

--- a/DemoManagement.cs
+++ b/DemoManagement.cs
@@ -21,6 +21,7 @@ namespace MatchZy
 
         public bool isDemoRecording = false;
         public bool isDemoRecordingEnabled = true;
+        public bool isDemoUploadS3Enabled = false;
 
         public void StartDemoRecording()
         {
@@ -78,7 +79,7 @@ namespace MatchZy
                 {
                     Task.Run(async () =>
                     {
-                        await UploadFileAsync(demoPath, demoUploadURL, demoUploadHeaderKey, demoUploadHeaderValue, liveMatchId, currentMapNumber, roundNumber);
+                        await UploadFileAsync(demoPath, demoUploadURL, demoUploadHeaderKey, demoUploadHeaderValue, liveMatchId, currentMapNumber, roundNumber, isDemoUploadS3Enabled);
                     });
                 });
             });

--- a/Utility.cs
+++ b/Utility.cs
@@ -1853,7 +1853,7 @@ namespace MatchZy
             return value;
         }
 
-        public async Task UploadFileAsync(string? filePath, string fileUploadURL, string headerKey, string headerValue, long matchId, int mapNumber, int roundNumber)
+        public async Task UploadFileAsync(string? filePath, string fileUploadURL, string headerKey, string headerValue, long matchId, int mapNumber, int roundNumber, bool useS3PresignedPut = false)
         {
             if (filePath == null || fileUploadURL == "")
             {
@@ -1864,11 +1864,43 @@ namespace MatchZy
             try
             {
                 using var httpClient = new HttpClient();
-                Log($"[UploadFileAsync] Going to upload the file on {fileUploadURL}. Complete path: {filePath}");
+                if (useS3PresignedPut)
+                {
+                    httpClient.Timeout = TimeSpan.FromHours(2);
+                }
+
+                Log($"[UploadFileAsync] Going to upload the file on {fileUploadURL}. Complete path: {filePath}" + (useS3PresignedPut ? " (HTTP PUT, S3-compatible)" : ""));
 
                 if (!File.Exists(filePath))
                 {
                     Log($"[UploadFileAsync ERROR] File not found: {filePath}");
+                    return;
+                }
+
+                if (useS3PresignedPut)
+                {
+                    using FileStream s3FileStream = File.OpenRead(filePath);
+                    using StreamContent s3Content = new(s3FileStream);
+                    s3Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+
+                    using HttpRequestMessage request = new(HttpMethod.Put, fileUploadURL) { Content = s3Content };
+
+                    if (!string.IsNullOrEmpty(headerKey) && !string.IsNullOrEmpty(headerValue))
+                    {
+                        request.Headers.TryAddWithoutValidation(headerKey, headerValue);
+                    }
+
+                    HttpResponseMessage s3Response = await httpClient.SendAsync(request);
+
+                    if (s3Response.IsSuccessStatusCode)
+                    {
+                        Log($"[UploadFileAsync] File upload successful for matchId: {matchId} mapNumber: {mapNumber} fileName: {Path.GetFileName(filePath)}.");
+                    }
+                    else
+                    {
+                        Log($"[UploadFileAsync ERROR] Failed to upload file. Status code: {s3Response.StatusCode} Response: {await s3Response.Content.ReadAsStringAsync()}");
+                    }
+
                     return;
                 }
 

--- a/cfg/MatchZy/config.cfg
+++ b/cfg/MatchZy/config.cfg
@@ -88,6 +88,9 @@ matchzy_reset_cvars_on_series_end true
 // If defined, recorded demos will be uploaded to this URL once the map ends
 matchzy_demo_upload_url ""
 
+// If 1, demo upload uses HTTP PUT to matchzy_demo_upload_url (e.g. S3 presigned URL) with raw .dem body. Default: 0
+matchzy_demo_upload_s3 0
+
 // Whether the plugin will load the match mode, the practice mode or neither by startup. 
 // 0 for neither, 1 for match mode, 2 for practice mode. Default: 1
 matchzy_autostart_mode 1

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -81,6 +81,9 @@ Again, inside `csgo/cfg/MatchZy`, a file named `config.cfg` should be present. T
 :   If defined, recorded demo will be [uploaded](../gotv#automatic-upload) to this URL once the map ends. Make sure that the URL is wrapped in double quotes (""). 
 Example: `matchzy_demo_upload_url "https://your-website.com/upload-endpoint"` <br>**`Default: ""`**
 
+####`matchzy_demo_upload_s3`
+:   If true, the demo is uploaded with **HTTP PUT** to `matchzy_demo_upload_url` (e.g. S3 presigned URL) as raw `.dem` bytes with `Content-Type: application/octet-stream`. If false, MatchZy uses the original **POST** behaviour with MatchZy metadata headers. See [GOTV / automatic upload](../gotv#s3-compatible-direct-upload-presigned-url).<br>**`Default: false`**
+
 ####`matchzy_kick_when_no_match_loaded`
 :   Whether to kick all clients and prevent anyone from joining the server if no match is loaded. This means if server is in match mode, a match needs to be set-up using `matchzy_loadmatch`/`matchzy_loadmatch_url` to load and configure a match.<br>**`Default: false`**
 

--- a/documentation/docs/gotv.md
+++ b/documentation/docs/gotv.md
@@ -32,6 +32,15 @@ read the [headers](#headers) for file metadata.
 
 Example: `matchzy_demo_upload_url "https://your-website.com/upload-endpoint"`
 
+### S3-compatible direct upload (presigned URL)
+
+Large demos are often uploaded straight to object storage using a **presigned URL** so the game server performs an **HTTP PUT** of the raw `.dem` file instead of posting through your application (which may hit body size limits).
+
+1. Set `matchzy_demo_upload_url` to the presigned PUT URL your backend issues for that map (or configure it the same way you already set the upload URL).
+2. Set `matchzy_demo_upload_s3 1` so MatchZy uses **HTTP PUT** with `Content-Type: application/octet-stream` and the raw demo bytes. MatchZy-specific metadata headers are **not** sent on this path, so they do not break AWS Signature Version 4 signing.
+
+Generate the presigned URL with the same `Content-Type` (`application/octet-stream`) you intend to send, or adjust your signing parameters accordingly for S3-compatible providers.
+
 ### Headers
 
 MatchZy will add these HTTP headers to its demo upload request:


### PR DESCRIPTION
Hello there. It's been while since I was away from CS2.
I've added demo upload feature for supporting S3 style object storage such as AWS S3 or Cloudflare R2.

## Summary
Implements [issue #378](https://github.com/shobhit-pathak/MatchZy/issues/378): optional **HTTP PUT** of raw `.dem` bytes to `matchzy_demo_upload_url` (e.g. S3 / R2 presigned URL), avoiding intermediary POST body limits for large demos.

## Changes
- New cvars: `matchzy_demo_upload_s3` / `get5_demo_upload_s3` (default: false)
- When enabled: **PUT** with `Content-Type: application/octet-stream`, streaming upload, extended timeout; **no** MatchZy/Get5 metadata headers (SigV4-safe)
- Documentation + sample `config.cfg` + changelog

## Usage
```
matchzy_demo_upload_url "<presigned-put-url>"
matchzy_demo_upload_s3 1
```
Presigned URL should be generated with `Content-Type: application/octet-stream` to match the client.

Made with [Cursor](https://cursor.com)